### PR TITLE
feat: certificate chain serving and remote signing oracle

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,36 @@ defer ca.Close()
 mux := http.NewServeMux()
 mux.Handle("/", ca.Handler())
 ```
+
+### Certificate chain serving
+
+When nanoca is deployed as an intermediate CA, ACME clients need the full certificate chain to build a trust path. Pass the chain to the in-process issuer after the signer argument:
+
+```go
+// intermCert is the issuing intermediate, rootCert is the root CA.
+// Order matters: issuer of the leaf first, then its issuer, up toward the root.
+issuer := inprocess.New(intermCert, intermSigner, intermCert, rootCert)
+```
+
+The ACME certificate endpoint will return the leaf followed by each chain certificate as a PEM-encoded `application/pem-certificate-chain` response per RFC 8555 Section 7.4.2. Callers that don't pass a chain get the previous behavior (leaf only).
+
+### Remote signing oracle
+
+The `signers/remote` package provides a `crypto.Signer` that delegates signing to an external HTTP service, allowing the CA private key to live in an HSM, cloud KMS, or any custom signing service.
+
+```go
+import "github.com/brandonweeks/nanoca/signers/remote"
+
+signer, err := remote.New(
+	"https://signer.internal:8443",  // oracle URL (must be HTTPS)
+	"bearer-token",                   // Authorization header value
+	publicKeyPEM,                     // PEM-encoded ECDSA public key
+)
+```
+
+The oracle protocol is a single endpoint:
+
+- `POST /sign` with `Authorization: Bearer <token>` and JSON body `{"digest": "<base64>", "hash": "SHA-256"}`
+- Response: `{"signature": "<base64-DER>"}`
+
+The signer verifies every signature returned by the oracle against the known public key before passing it to the caller. Plain HTTP is rejected unless the oracle is on a loopback address.

--- a/handlers.go
+++ b/handlers.go
@@ -546,11 +546,17 @@ func (ca *CA) handleCertificate(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Replay-Nonce", nonce)
 	w.WriteHeader(http.StatusOK)
 
-	pemCert := pem.EncodeToMemory(&pem.Block{
+	_, _ = w.Write(pem.EncodeToMemory(&pem.Block{
 		Type:  "CERTIFICATE",
 		Bytes: cert.Raw,
-	})
-	_, _ = w.Write(pemCert)
+	}))
+
+	for _, raw := range cert.ChainRaw {
+		_, _ = w.Write(pem.EncodeToMemory(&pem.Block{
+			Type:  "CERTIFICATE",
+			Bytes: raw,
+		}))
+	}
 }
 
 func (ca *CA) writeJSONResponse(ctx context.Context, w http.ResponseWriter, statusCode int, data any, nonce string) {

--- a/integration_test.go
+++ b/integration_test.go
@@ -220,6 +220,21 @@ func TestDeviceAttestationFlow(t *testing.T) {
 			t.Logf("  Valid From: %s", parsedCert.NotBefore.Format(time.RFC3339))
 			t.Logf("  Valid Until: %s", parsedCert.NotAfter.Format(time.RFC3339))
 			t.Logf("  Certificate URL: %s", certURL)
+
+			if len(cert) < 2 {
+				t.Fatal("Expected at least two certificates in the chain (leaf + intermediate), got only one")
+			}
+
+			intermediateCert, err := x509.ParseCertificate(cert[1])
+			if err != nil {
+				t.Fatalf("Failed to parse intermediate certificate: %v", err)
+			}
+			if !intermediateCert.IsCA {
+				t.Error("Second certificate in chain should be a CA certificate")
+			}
+			if intermediateCert.Subject.CommonName != "Test Intermediate CA" {
+				t.Errorf("Intermediate common name = %v, want Test Intermediate CA", intermediateCert.Subject.CommonName)
+			}
 		} else {
 			t.Error("No certificate data returned")
 		}
@@ -259,6 +274,31 @@ func setupTestServerWithAttestation(t *testing.T) (*httptest.Server, *nanoca.CA)
 		t.Fatalf("Failed to parse CA certificate: %v", err)
 	}
 
+	intermKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("Failed to generate intermediate key: %v", err)
+	}
+
+	intermCertTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject: pkix.Name{
+			CommonName: "Test Intermediate CA",
+		},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+	}
+
+	intermCertDER, err := x509.CreateCertificate(rand.Reader, intermCertTemplate, caCert, &intermKey.PublicKey, signer)
+	if err != nil {
+		t.Fatalf("Failed to create intermediate CA certificate: %v", err)
+	}
+
+	intermCert, err := x509.ParseCertificate(intermCertDER)
+	if err != nil {
+		t.Fatalf("Failed to parse intermediate CA certificate: %v", err)
+	}
+
 	storage, err := store.New(store.Options{InMemory: true})
 	if err != nil {
 		t.Fatalf("Failed to create in-memory storage: %v", err)
@@ -266,7 +306,7 @@ func setupTestServerWithAttestation(t *testing.T) (*httptest.Server, *nanoca.CA)
 
 	ca, err := nanoca.New(
 		slog.New(slog.DiscardHandler),
-		inprocess.New(caCert, signer),
+		inprocess.New(intermCert, intermKey, intermCert, caCert),
 		nullauthorizer.New(),
 		storage,
 		ts.URL,

--- a/issuers/inprocess/inprocess.go
+++ b/issuers/inprocess/inprocess.go
@@ -15,13 +15,20 @@ import (
 type Issuer struct {
 	caCert *x509.Certificate
 	signer crypto.Signer
+	chain  []*x509.Certificate
 }
 
-// New creates a new in-process certificate issuer
-func New(caCert *x509.Certificate, signer crypto.Signer) *Issuer {
+// New creates a new in-process certificate issuer.
+//
+// The optional chain parameter specifies additional certificates to include
+// in the ACME certificate response after the leaf, per RFC 8555 Section 7.4.2.
+// Certificates must be ordered issuer-first: the CA that signed the leaf,
+// then its issuer, and so on up to (but not necessarily including) the root.
+func New(caCert *x509.Certificate, signer crypto.Signer, chain ...*x509.Certificate) *Issuer {
 	return &Issuer{
 		caCert: caCert,
 		signer: signer,
+		chain:  chain,
 	}
 }
 
@@ -55,9 +62,16 @@ func (di *Issuer) IssueCertificate(csr *x509.CertificateRequest, deviceInfos []*
 		return nil, fmt.Errorf("failed to parse generated certificate: %w", err)
 	}
 
+	chainRaw := make([][]byte, len(di.chain))
+	for i, c := range di.chain {
+		chainRaw[i] = c.Raw
+	}
+
 	return &nanoca.Certificate{
 		Certificate:  x509Cert,
 		Raw:          certDER,
 		SerialNumber: x509Cert.SerialNumber.String(),
+		Chain:        di.chain,
+		ChainRaw:     chainRaw,
 	}, nil
 }

--- a/issuers/inprocess/inprocess_test.go
+++ b/issuers/inprocess/inprocess_test.go
@@ -46,126 +46,248 @@ func createTestCA(t *testing.T) (*x509.Certificate, *ecdsa.PrivateKey) {
 	return cert, key
 }
 
+func createTestIntermediateCA(t *testing.T, parentCert *x509.Certificate, parentKey *ecdsa.PrivateKey) (*x509.Certificate, *ecdsa.PrivateKey) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("Failed to generate intermediate CA key: %v", err)
+	}
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject: pkix.Name{
+			CommonName:   "Test Intermediate CA",
+			Organization: []string{"Test CA Org"},
+		},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, parentCert, &key.PublicKey, parentKey)
+	if err != nil {
+		t.Fatalf("Failed to create intermediate CA certificate: %v", err)
+	}
+
+	cert, err := x509.ParseCertificate(certDER)
+	if err != nil {
+		t.Fatalf("Failed to parse intermediate CA certificate: %v", err)
+	}
+
+	return cert, key
+}
+
 func TestIssuer_IssueCertificate(t *testing.T) {
 	t.Parallel()
 
 	caCert, signer := createTestCA(t)
 
-	issuer := New(caCert, signer)
+	t.Run("no chain", func(t *testing.T) {
+		issuer := New(caCert, signer)
 
-	csrKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	if err != nil {
-		t.Fatalf("Failed to generate CSR key: %v", err)
-	}
+		csrKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		if err != nil {
+			t.Fatalf("Failed to generate CSR key: %v", err)
+		}
 
-	csrTemplate := &x509.CertificateRequest{
-		Subject: pkix.Name{
-			CommonName:   "Test Device",
-			Organization: []string{"Test Org"},
-		},
-	}
-
-	csrDER, err := x509.CreateCertificateRequest(rand.Reader, csrTemplate, csrKey)
-	if err != nil {
-		t.Fatalf("Failed to create CSR: %v", err)
-	}
-
-	csr, err := x509.ParseCertificateRequest(csrDER)
-	if err != nil {
-		t.Fatalf("Failed to parse CSR: %v", err)
-	}
-
-	hwTypeOID := asn1.ObjectIdentifier{1, 2, 840, 113635, 100, 8, 9, 2}
-	deviceInfos := []*nanoca.DeviceInfo{
-		{
-			PermanentIdentifier: &nanoca.PermanentIdentifier{
-				Identifier: "device-123",
-				Assigner:   asn1.ObjectIdentifier{1, 2, 3, 4},
+		csrTemplate := &x509.CertificateRequest{
+			Subject: pkix.Name{
+				CommonName:   "Test Device",
+				Organization: []string{"Test Org"},
 			},
-			HardwareModule: &nanoca.HardwareModule{
-				Type:  hwTypeOID,
-				Value: []byte("UDID-ABC-123"),
+		}
+
+		csrDER, err := x509.CreateCertificateRequest(rand.Reader, csrTemplate, csrKey)
+		if err != nil {
+			t.Fatalf("Failed to create CSR: %v", err)
+		}
+
+		csr, err := x509.ParseCertificateRequest(csrDER)
+		if err != nil {
+			t.Fatalf("Failed to parse CSR: %v", err)
+		}
+
+		cert, err := issuer.IssueCertificate(csr, nil)
+		if err != nil {
+			t.Fatalf("IssueCertificate() error = %v", err)
+		}
+
+		if len(cert.Chain) != 0 {
+			t.Errorf("cert.Chain length = %d, want 0", len(cert.Chain))
+		}
+		if len(cert.ChainRaw) != 0 {
+			t.Errorf("cert.ChainRaw length = %d, want 0", len(cert.ChainRaw))
+		}
+	})
+
+	t.Run("with intermediate chain", func(t *testing.T) {
+		intermCert, intermSigner := createTestIntermediateCA(t, caCert, signer)
+		issuer := New(intermCert, intermSigner, intermCert, caCert)
+
+		csrKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		if err != nil {
+			t.Fatalf("Failed to generate CSR key: %v", err)
+		}
+
+		csrTemplate := &x509.CertificateRequest{
+			Subject: pkix.Name{
+				CommonName: "Test Device With Chain",
 			},
-		},
-	}
+		}
 
-	cert, err := issuer.IssueCertificate(csr, deviceInfos)
-	if err != nil {
-		t.Fatalf("IssueCertificate() error = %v", err)
-	}
-	if cert == nil {
-		t.Fatal("IssueCertificate() returned nil certificate")
-	}
+		csrDER, err := x509.CreateCertificateRequest(rand.Reader, csrTemplate, csrKey)
+		if err != nil {
+			t.Fatalf("Failed to create CSR: %v", err)
+		}
 
-	if cert.Certificate == nil {
-		t.Error("Certificate.Certificate is nil")
-	}
-	if len(cert.Raw) == 0 {
-		t.Error("Certificate.Raw is empty")
-	}
-	if cert.SerialNumber == "" {
-		t.Error("Certificate.SerialNumber is empty")
-	}
+		csr, err := x509.ParseCertificateRequest(csrDER)
+		if err != nil {
+			t.Fatalf("Failed to parse CSR: %v", err)
+		}
 
-	x509Cert := cert.Certificate
-	if x509Cert.Subject.CommonName != "Test Device" {
-		t.Errorf("Certificate CommonName = %v, want Test Device", x509Cert.Subject.CommonName)
-	}
-	if x509Cert.Issuer.CommonName != caCert.Subject.CommonName {
-		t.Errorf("Certificate Issuer CN = %v, want %v", x509Cert.Issuer.CommonName, caCert.Subject.CommonName)
-	}
-	if x509Cert.KeyUsage&x509.KeyUsageDigitalSignature == 0 {
-		t.Error("Certificate should have DigitalSignature key usage")
-	}
-	if x509Cert.KeyUsage&x509.KeyUsageKeyEncipherment == 0 {
-		t.Error("Certificate should have KeyEncipherment key usage")
-	}
-	if len(x509Cert.ExtKeyUsage) == 0 || x509Cert.ExtKeyUsage[0] != x509.ExtKeyUsageClientAuth {
-		t.Error("Certificate should have ClientAuth extended key usage")
-	}
+		cert, err := issuer.IssueCertificate(csr, nil)
+		if err != nil {
+			t.Fatalf("IssueCertificate() error = %v", err)
+		}
 
-	sanExt := certutil.FindExtension(x509Cert, certutil.OIDSubjectAltName)
-	if sanExt == nil {
-		t.Fatal("Certificate should have a SubjectAltName extension")
-	}
+		if len(cert.Chain) != 2 {
+			t.Fatalf("cert.Chain length = %d, want 2", len(cert.Chain))
+		}
+		if cert.Chain[0] != intermCert {
+			t.Errorf("cert.Chain[0] = %v, want %v", cert.Chain[0].Subject.CommonName, intermCert.Subject.CommonName)
+		}
+		if cert.Chain[1] != caCert {
+			t.Errorf("cert.Chain[1] = %v, want %v", cert.Chain[1].Subject.CommonName, caCert.Subject.CommonName)
+		}
 
-	otherNames, err := certutil.ParseOtherNames(sanExt.Value)
-	if err != nil {
-		t.Fatalf("ParseOtherNames() error = %v", err)
-	}
-	foundPI, foundHM := false, false
-	for _, on := range otherNames {
-		if on.TypeID.Equal(certutil.OIDPermanentIdentifier) {
-			foundPI = true
-			pi, err := certutil.ParsePermanentIdentifier(on.Value)
-			if err != nil {
-				t.Fatalf("ParsePermanentIdentifier() error = %v", err)
-			}
-			if pi.Identifier != "device-123" {
-				t.Errorf("PermanentIdentifier.Identifier = %q, want %q", pi.Identifier, "device-123")
-			}
-			if !pi.Assigner.Equal(asn1.ObjectIdentifier{1, 2, 3, 4}) {
-				t.Errorf("PermanentIdentifier.Assigner = %v, want %v", pi.Assigner, asn1.ObjectIdentifier{1, 2, 3, 4})
+		if len(cert.ChainRaw) != 2 {
+			t.Fatalf("cert.ChainRaw length = %d, want 2", len(cert.ChainRaw))
+		}
+		for i, raw := range cert.ChainRaw {
+			if string(raw) != string(cert.Chain[i].Raw) {
+				t.Errorf("cert.ChainRaw[%d] mismatch", i)
 			}
 		}
-		if on.TypeID.Equal(certutil.OIDHardwareModuleName) {
-			foundHM = true
-			hm, err := certutil.ParseHardwareModule(on.Value)
-			if err != nil {
-				t.Fatalf("ParseHardwareModule() error = %v", err)
+	})
+
+	t.Run("existing test case", func(t *testing.T) {
+		issuer := New(caCert, signer)
+
+		csrKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		if err != nil {
+			t.Fatalf("Failed to generate CSR key: %v", err)
+		}
+
+		csrTemplate := &x509.CertificateRequest{
+			Subject: pkix.Name{
+				CommonName:   "Test Device",
+				Organization: []string{"Test Org"},
+			},
+		}
+
+		csrDER, err := x509.CreateCertificateRequest(rand.Reader, csrTemplate, csrKey)
+		if err != nil {
+			t.Fatalf("Failed to create CSR: %v", err)
+		}
+
+		csr, err := x509.ParseCertificateRequest(csrDER)
+		if err != nil {
+			t.Fatalf("Failed to parse CSR: %v", err)
+		}
+
+		hwTypeOID := asn1.ObjectIdentifier{1, 2, 840, 113635, 100, 8, 9, 2}
+		deviceInfos := []*nanoca.DeviceInfo{
+			{
+				PermanentIdentifier: &nanoca.PermanentIdentifier{
+					Identifier: "device-123",
+					Assigner:   asn1.ObjectIdentifier{1, 2, 3, 4},
+				},
+				HardwareModule: &nanoca.HardwareModule{
+					Type:  hwTypeOID,
+					Value: []byte("UDID-ABC-123"),
+				},
+			},
+		}
+
+		cert, err := issuer.IssueCertificate(csr, deviceInfos)
+		if err != nil {
+			t.Fatalf("IssueCertificate() error = %v", err)
+		}
+		if cert == nil {
+			t.Fatal("IssueCertificate() returned nil certificate")
+		}
+
+		if cert.Certificate == nil {
+			t.Error("Certificate.Certificate is nil")
+		}
+		if len(cert.Raw) == 0 {
+			t.Error("Certificate.Raw is empty")
+		}
+		if cert.SerialNumber == "" {
+			t.Error("Certificate.SerialNumber is empty")
+		}
+
+		x509Cert := cert.Certificate
+		if x509Cert.Subject.CommonName != "Test Device" {
+			t.Errorf("Certificate CommonName = %v, want Test Device", x509Cert.Subject.CommonName)
+		}
+		if x509Cert.Issuer.CommonName != caCert.Subject.CommonName {
+			t.Errorf("Certificate Issuer CN = %v, want %v", x509Cert.Issuer.CommonName, caCert.Subject.CommonName)
+		}
+		if x509Cert.KeyUsage&x509.KeyUsageDigitalSignature == 0 {
+			t.Error("Certificate should have DigitalSignature key usage")
+		}
+		if x509Cert.KeyUsage&x509.KeyUsageKeyEncipherment == 0 {
+			t.Error("Certificate should have KeyEncipherment key usage")
+		}
+		if len(x509Cert.ExtKeyUsage) == 0 || x509Cert.ExtKeyUsage[0] != x509.ExtKeyUsageClientAuth {
+			t.Error("Certificate should have ClientAuth extended key usage")
+		}
+
+		sanExt := certutil.FindExtension(x509Cert, certutil.OIDSubjectAltName)
+		if sanExt == nil {
+			t.Fatal("Certificate should have a SubjectAltName extension")
+		}
+
+		otherNames, err := certutil.ParseOtherNames(sanExt.Value)
+		if err != nil {
+			t.Fatalf("ParseOtherNames() error = %v", err)
+		}
+		foundPI, foundHM := false, false
+		for _, on := range otherNames {
+			if on.TypeID.Equal(certutil.OIDPermanentIdentifier) {
+				foundPI = true
+				pi, err := certutil.ParsePermanentIdentifier(on.Value)
+				if err != nil {
+					t.Fatalf("ParsePermanentIdentifier() error = %v", err)
+				}
+				if pi.Identifier != "device-123" {
+					t.Errorf("PermanentIdentifier.Identifier = %q, want %q", pi.Identifier, "device-123")
+				}
+				if !pi.Assigner.Equal(asn1.ObjectIdentifier{1, 2, 3, 4}) {
+					t.Errorf("PermanentIdentifier.Assigner = %v, want %v", pi.Assigner, asn1.ObjectIdentifier{1, 2, 3, 4})
+				}
 			}
-			if !hm.Type.Equal(hwTypeOID) {
-				t.Errorf("HardwareModule.Type = %v, want %v", hm.Type, hwTypeOID)
-			}
-			if string(hm.Value) != "UDID-ABC-123" {
-				t.Errorf("HardwareModule.Value = %q, want %q", hm.Value, "UDID-ABC-123")
+			if on.TypeID.Equal(certutil.OIDHardwareModuleName) {
+				foundHM = true
+				hm, err := certutil.ParseHardwareModule(on.Value)
+				if err != nil {
+					t.Fatalf("ParseHardwareModule() error = %v", err)
+				}
+				if !hm.Type.Equal(hwTypeOID) {
+					t.Errorf("HardwareModule.Type = %v, want %v", hm.Type, hwTypeOID)
+				}
+				if string(hm.Value) != "UDID-ABC-123" {
+					t.Errorf("HardwareModule.Value = %q, want %q", hm.Value, "UDID-ABC-123")
+				}
 			}
 		}
-	}
-	if !foundPI {
-		t.Error("SAN extension should contain a PermanentIdentifier otherName")
-	}
-	if !foundHM {
-		t.Error("SAN extension should contain a HardwareModuleName otherName")
-	}
+		if !foundPI {
+			t.Error("SAN extension should contain a PermanentIdentifier otherName")
+		}
+		if !foundHM {
+			t.Error("SAN extension should contain a HardwareModuleName otherName")
+		}
+	})
 }

--- a/signers/remote/remote.go
+++ b/signers/remote/remote.go
@@ -1,0 +1,193 @@
+// Package remote provides a crypto.Signer implementation that delegates
+// signing operations to an authenticated HTTP signing oracle.
+//
+// The oracle protocol is minimal:
+//
+//	POST /sign
+//	Authorization: Bearer <token>
+//	Content-Type: application/json
+//
+//	Request:  {"digest": "<base64>", "hash": "<SHA-256|SHA-384|SHA-512>"}
+//	Response: {"signature": "<base64-DER>"}
+//
+// The digest field contains the pre-hashed digest as produced by
+// crypto/x509 internals — callers must not hash again.
+// The signature field must be a DER-encoded ASN.1 ECDSA signature
+// (not IEEE P1363 / raw r||s concatenation).
+package remote
+
+import (
+	"bytes"
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+	"unicode"
+)
+
+// Signer delegates crypto.Signer operations to a remote HTTP signing oracle.
+type Signer struct {
+	oracleURL  string
+	authToken  string
+	publicKey  crypto.PublicKey
+	httpClient *http.Client
+}
+
+// New creates a remote signer.
+//
+// oracleURL is the base URL of the signing oracle (e.g. https://signer.example.com).
+// The URL must use HTTPS; plain HTTP is only permitted for loopback addresses
+// (localhost, 127.0.0.1, ::1) to support development and testing.
+// authToken is sent as a Bearer token in the Authorization header.
+// publicKeyPEM is the PKIX PEM-encoded public key corresponding to the
+// private key held by the oracle. It is used to satisfy crypto.Signer.Public()
+// and is never sent to the oracle. After each signing operation, the returned
+// signature is verified against this key before being returned to the caller.
+func New(oracleURL, authToken, publicKeyPEM string) (*Signer, error) {
+	if err := validateOracleURL(oracleURL); err != nil {
+		return nil, fmt.Errorf("remote signer: %w", err)
+	}
+	pub, err := parsePublicKeyPEM(publicKeyPEM)
+	if err != nil {
+		return nil, fmt.Errorf("remote signer: parsing public key: %w", err)
+	}
+	return &Signer{
+		oracleURL: oracleURL,
+		authToken: authToken,
+		publicKey: pub,
+		httpClient: &http.Client{
+			Timeout: 10 * time.Second,
+		},
+	}, nil
+}
+
+// Public returns the public key corresponding to the private key held by the oracle.
+func (s *Signer) Public() crypto.PublicKey { return s.publicKey }
+
+type signRequest struct {
+	Digest string `json:"digest"`
+	Hash   string `json:"hash"`
+}
+
+type signResponse struct {
+	Signature string `json:"signature"`
+}
+
+// Sign sends the digest to the oracle and returns a DER-encoded signature.
+// digest is the pre-hashed digest as passed by crypto/x509 internals.
+// The oracle is responsible for not hashing again.
+//
+// Note: the crypto.Signer interface does not accept a context, so this method
+// uses context.Background(). Cancellation relies on the http.Client timeout.
+func (s *Signer) Sign(_ io.Reader, digest []byte, opts crypto.SignerOpts) ([]byte, error) {
+	if opts == nil {
+		return nil, errors.New("remote signer: signer opts are required")
+	}
+
+	reqBody, err := json.Marshal(signRequest{
+		Digest: base64.StdEncoding.EncodeToString(digest),
+		Hash:   opts.HashFunc().String(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("remote signer: marshalling request: %w", err)
+	}
+
+	u, err := url.JoinPath(s.oracleURL, "sign")
+	if err != nil {
+		return nil, fmt.Errorf("remote signer: building oracle URL: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, u, bytes.NewReader(reqBody))
+	if err != nil {
+		return nil, fmt.Errorf("remote signer: building request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+s.authToken)
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("remote signer: oracle request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	const maxResponseSize = 1 << 20 // 1MB
+	const maxErrorSize = 4096       // 4KB
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorSize))
+		return nil, fmt.Errorf("remote signer: oracle returned %d: %s", resp.StatusCode, sanitizeErrorBody(body))
+	}
+
+	var sr signResponse
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxResponseSize)).Decode(&sr); err != nil {
+		return nil, fmt.Errorf("remote signer: decoding oracle response: %w", err)
+	}
+
+	sig, err := base64.StdEncoding.DecodeString(sr.Signature)
+	if err != nil {
+		return nil, fmt.Errorf("remote signer: decoding signature bytes: %w", err)
+	}
+
+	ecPub, ok := s.publicKey.(*ecdsa.PublicKey)
+	if !ok {
+		return nil, errors.New("remote signer: public key is not ECDSA")
+	}
+	if !ecdsa.VerifyASN1(ecPub, digest, sig) {
+		return nil, errors.New("remote signer: oracle returned invalid signature")
+	}
+
+	return sig, nil
+}
+
+// sanitizeErrorBody strips control characters from oracle error responses
+// to prevent log injection.
+func sanitizeErrorBody(body []byte) string {
+	return strings.Map(func(r rune) rune {
+		if unicode.IsControl(r) && r != ' ' {
+			return '?'
+		}
+		return r
+	}, string(body))
+}
+
+func validateOracleURL(oracleURL string) error {
+	u, err := url.Parse(oracleURL)
+	if err != nil {
+		return fmt.Errorf("invalid oracle URL: %w", err)
+	}
+	if u.Scheme == "https" {
+		return nil
+	}
+	if u.Scheme == "http" {
+		host := u.Hostname()
+		if host == "localhost" || host == "127.0.0.1" || host == "::1" {
+			return nil
+		}
+	}
+	return errors.New("oracle URL must use HTTPS (plain HTTP is only allowed for loopback addresses)")
+}
+
+func parsePublicKeyPEM(pemStr string) (crypto.PublicKey, error) {
+	block, _ := pem.Decode([]byte(pemStr))
+	if block == nil {
+		return nil, errors.New("no PEM block found")
+	}
+	key, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parsing PKIX public key: %w", err)
+	}
+	if _, ok := key.(*ecdsa.PublicKey); !ok {
+		return nil, fmt.Errorf("expected ECDSA public key, got %T", key)
+	}
+	return key, nil
+}

--- a/signers/remote/remote_test.go
+++ b/signers/remote/remote_test.go
@@ -1,0 +1,331 @@
+package remote
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func generateP256PEM(t *testing.T) (string, *ecdsa.PrivateKey) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+	der, err := x509.MarshalPKIXPublicKey(&key.PublicKey)
+	if err != nil {
+		t.Fatalf("failed to marshal public key: %v", err)
+	}
+	return string(pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der})), key
+}
+
+func generateRSAPEM(t *testing.T) string {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate RSA key: %v", err)
+	}
+	der, err := x509.MarshalPKIXPublicKey(&key.PublicKey)
+	if err != nil {
+		t.Fatalf("failed to marshal RSA public key: %v", err)
+	}
+	return string(pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der}))
+}
+
+func TestNew_validKey(t *testing.T) {
+	pemStr, _ := generateP256PEM(t)
+	signer, err := New("http://localhost:8080", "token", pemStr)
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+	if signer.Public() == nil {
+		t.Fatal("Public() returned nil")
+	}
+}
+
+func TestNew_invalidKey(t *testing.T) {
+	_, err := New("http://localhost:8080", "token", "garbage")
+	if err == nil {
+		t.Fatal("New() should have failed with garbage PEM")
+	}
+}
+
+func TestNew_wrongKeyType(t *testing.T) {
+	pemStr := generateRSAPEM(t)
+	_, err := New("http://localhost:8080", "token", pemStr)
+	if err == nil {
+		t.Fatal("New() should have failed with RSA key")
+	}
+	if !strings.Contains(err.Error(), "expected ECDSA public key") {
+		t.Errorf("expected error message to contain 'expected ECDSA public key', got: %v", err)
+	}
+}
+
+func TestSign_success(t *testing.T) {
+	pemStr, key := generateP256PEM(t)
+	digest := []byte("this is a digest")
+	token := "secret-token"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/sign" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Header.Get("Authorization") != "Bearer "+token {
+			t.Errorf("unexpected auth header: %s", r.Header.Get("Authorization"))
+		}
+		var req signRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("failed to decode request: %v", err)
+		}
+		decodedDigest, _ := base64.StdEncoding.DecodeString(req.Digest)
+		if string(decodedDigest) != string(digest) {
+			t.Errorf("digest mismatch: %s != %s", string(decodedDigest), string(digest))
+		}
+
+		sig, err := key.Sign(rand.Reader, decodedDigest, crypto.SHA256)
+		if err != nil {
+			t.Errorf("failed to sign: %v", err)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(signResponse{
+			Signature: base64.StdEncoding.EncodeToString(sig),
+		})
+	}))
+	defer ts.Close()
+
+	signer, _ := New(ts.URL, token, pemStr)
+	sig, err := signer.Sign(nil, digest, crypto.SHA256)
+	if err != nil {
+		t.Fatalf("Sign() failed: %v", err)
+	}
+	if len(sig) == 0 {
+		t.Fatal("Sign() returned empty signature")
+	}
+}
+
+func TestSign_invalidSignature(t *testing.T) {
+	pemStr, _ := generateP256PEM(t)
+	// Use a different key to produce a valid DER signature that won't verify
+	// against the public key the signer was constructed with.
+	wrongKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate wrong key: %v", err)
+	}
+	digest := []byte("this is a digest")
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		sig, sigErr := wrongKey.Sign(rand.Reader, digest, crypto.SHA256)
+		if sigErr != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(signResponse{
+			Signature: base64.StdEncoding.EncodeToString(sig),
+		})
+	}))
+	defer ts.Close()
+
+	signer, _ := New(ts.URL, "token", pemStr)
+	_, err = signer.Sign(nil, digest, crypto.SHA256)
+	if err == nil {
+		t.Fatal("Sign() should have failed with wrong-key signature")
+	}
+	if !strings.Contains(err.Error(), "oracle returned invalid signature") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestSign_oracleError(t *testing.T) {
+	pemStr, _ := generateP256PEM(t)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("oracle error"))
+	}))
+	defer ts.Close()
+
+	signer, _ := New(ts.URL, "token", pemStr)
+	_, err := signer.Sign(nil, []byte("digest"), crypto.SHA256)
+	if err == nil {
+		t.Fatal("Sign() should have failed")
+	}
+	if !strings.Contains(err.Error(), "oracle returned 500") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestSign_oracleUnauthorized(t *testing.T) {
+	pemStr, _ := generateP256PEM(t)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte("unauthorized"))
+	}))
+	defer ts.Close()
+
+	signer, _ := New(ts.URL, "token", pemStr)
+	_, err := signer.Sign(nil, []byte("digest"), crypto.SHA256)
+	if err == nil {
+		t.Fatal("Sign() should have failed")
+	}
+	if !strings.Contains(err.Error(), "oracle returned 401") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestSign_networkError(t *testing.T) {
+	pemStr, _ := generateP256PEM(t)
+	// Unreachable URL
+	signer, _ := New("http://localhost:1", "token", pemStr)
+	_, err := signer.Sign(nil, []byte("digest"), crypto.SHA256)
+	if err == nil {
+		t.Fatal("Sign() should have failed")
+	}
+	if !strings.Contains(err.Error(), "oracle request failed") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestSign_malformedResponse(t *testing.T) {
+	pemStr, _ := generateP256PEM(t)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("not json"))
+	}))
+	defer ts.Close()
+
+	signer, _ := New(ts.URL, "token", pemStr)
+	_, err := signer.Sign(nil, []byte("digest"), crypto.SHA256)
+	if err == nil {
+		t.Fatal("Sign() should have failed")
+	}
+	if !strings.Contains(err.Error(), "decoding oracle response") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestSign_invalidBase64Signature(t *testing.T) {
+	pemStr, _ := generateP256PEM(t)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(signResponse{
+			Signature: "not-valid-base64!@#$",
+		})
+	}))
+	defer ts.Close()
+
+	signer, _ := New(ts.URL, "token", pemStr)
+	_, err := signer.Sign(nil, []byte("digest"), crypto.SHA256)
+	if err == nil {
+		t.Fatal("Sign() should have failed with invalid base64 signature")
+	}
+	if !strings.Contains(err.Error(), "decoding signature bytes") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestSign_responseTooLarge(t *testing.T) {
+	pemStr, _ := generateP256PEM(t)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Send a response larger than 1MB
+		largeSignature := strings.Repeat("A", 1<<20+100)
+		_ = json.NewEncoder(w).Encode(signResponse{
+			Signature: largeSignature,
+		})
+	}))
+	defer ts.Close()
+
+	signer, _ := New(ts.URL, "token", pemStr)
+	_, err := signer.Sign(nil, []byte("digest"), crypto.SHA256)
+	if err == nil {
+		t.Fatal("Sign() should have failed due to large response")
+	}
+	if !strings.Contains(err.Error(), "decoding oracle response") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestSign_errorTooLarge(t *testing.T) {
+	pemStr, _ := generateP256PEM(t)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		// Send an error body larger than 4KB
+		_, _ = w.Write([]byte(strings.Repeat("E", 8192)))
+	}))
+	defer ts.Close()
+
+	signer, _ := New(ts.URL, "token", pemStr)
+	_, err := signer.Sign(nil, []byte("digest"), crypto.SHA256)
+	if err == nil {
+		t.Fatal("Sign() should have failed")
+	}
+	// The implementation uses LimitReader(resp.Body, 4096), so the body read is limited.
+	if !strings.Contains(err.Error(), "oracle returned 500") {
+		t.Errorf("unexpected error: %v", err)
+	}
+	errStr := err.Error()
+	if len(errStr) > 5000 { // 4096 + some overhead for the message prefix
+		t.Errorf("error message too long: %d bytes", len(errStr))
+	}
+}
+
+func TestNew_rejectsPlaintextHTTP(t *testing.T) {
+	pemStr, _ := generateP256PEM(t)
+	_, err := New("http://signer.example.com", "token", pemStr)
+	if err == nil {
+		t.Fatal("New() should reject plain HTTP to non-loopback address")
+	}
+	if !strings.Contains(err.Error(), "must use HTTPS") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestNew_allowsHTTPLoopback(t *testing.T) {
+	pemStr, _ := generateP256PEM(t)
+	for _, addr := range []string{"localhost:8080", "127.0.0.1:8080", "[::1]:8080"} {
+		_, err := New("http://"+addr, "token", pemStr)
+		if err != nil {
+			t.Errorf("New() should allow HTTP to %s, got: %v", addr, err)
+		}
+	}
+}
+
+func TestNew_allowsHTTPS(t *testing.T) {
+	pemStr, _ := generateP256PEM(t)
+	_, err := New("https://signer.example.com", "token", pemStr)
+	if err != nil {
+		t.Errorf("New() should allow HTTPS, got: %v", err)
+	}
+}
+
+func TestSign_errorBodySanitized(t *testing.T) {
+	pemStr, _ := generateP256PEM(t)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		// Include control characters that could be used for log injection
+		_, _ = w.Write([]byte("error\ninjected-line\r\x00hidden"))
+	}))
+	defer ts.Close()
+
+	signer, _ := New(ts.URL, "token", pemStr)
+	_, err := signer.Sign(nil, []byte("digest"), crypto.SHA256)
+	if err == nil {
+		t.Fatal("Sign() should have failed")
+	}
+	errMsg := err.Error()
+	if strings.Contains(errMsg, "\n") || strings.Contains(errMsg, "\r") || strings.Contains(errMsg, "\x00") {
+		t.Errorf("error message contains unsanitized control characters: %q", errMsg)
+	}
+	if !strings.Contains(errMsg, "error?injected-line") {
+		t.Errorf("expected sanitized error body, got: %q", errMsg)
+	}
+}

--- a/types.go
+++ b/types.go
@@ -47,10 +47,18 @@ type HardwareModule struct {
 	Value []byte
 }
 
+// Certificate holds an issued certificate and its optional chain.
+//
+// ChainRaw is the authoritative representation of the chain and is persisted
+// to storage. Chain is a convenience field populated at issuance time but is
+// NOT reconstituted after a storage round-trip (JSON tags exclude it).
+// Code that consumes certificates retrieved from storage must use ChainRaw.
 type Certificate struct {
-	*x509.Certificate `json:"-"` // Exclude from JSON serialization
-	Raw               []byte     `json:"raw"`
-	SerialNumber      string     `json:"serialNumber"`
+	*x509.Certificate `json:"-"`
+	Raw               []byte              `json:"raw"`
+	SerialNumber      string              `json:"serialNumber"`
+	Chain             []*x509.Certificate `json:"-"`
+	ChainRaw          [][]byte            `json:"chainRaw,omitempty"`
 }
 
 type Directory struct {


### PR DESCRIPTION
## Summary

- **Certificate chain serving**: `handleCertificate` now returns the full PEM chain per RFC 8555 Section 7.4.2, not just the leaf. The in-process issuer accepts an optional variadic `chain` argument. Existing callers passing no chain are unaffected.
- **Remote signing oracle**: New `signers/remote` package providing a `crypto.Signer` that delegates to an external HTTP service (HSM, KMS, etc). Stdlib only, no provider-specific dependencies.
- **README fix**: The existing usage example showed `inprocess.New(signer)` with one argument, but the function signature was already `New(caCert, signer)` before these changes. Fixed to match the actual API -- this is a pre-existing documentation bug, not a regression from this PR.

## Security hardening (remote signer)

- Signatures are verified against the known public key after every oracle response
- Oracle URL must be HTTPS; plain HTTP only permitted for loopback addresses
- Oracle error bodies are sanitized to strip control characters (log injection prevention)
- Response bodies are size-limited (1MB success, 4KB error)

## Design notes

- `inprocess.New(caCert, signer)` still compiles unchanged (variadic chain)
- `testing/server.go` and `examples/nanomdm.go` are unmodified and compile as-is
- `signers/remote` imports only stdlib
- `ChainRaw` is the authoritative chain representation after storage round-trips; `Chain` is a convenience field populated at issuance time only (documented on the struct)
- `crypto.Signer` interface doesn't accept a context, so the oracle call uses `context.Background()` with a 10s client timeout

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes (16 tests for remote signer, chain tests for inprocess issuer, integration test with intermediate CA)
- [ ] `golangci-lint run` passes with no issues
- [ ] `inprocess.New(caCert, signer)` compiles with no chain arg
- [ ] `inprocess.New(caCert, signer, intermCert, rootCert)` produces cert with two chain entries
- [ ] Certificate endpoint returns multiple PEM blocks when chain is present