### PR TITLE
feat: serve full certificate chain in ACME certificate endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,10 @@ caCert, _ := /* load your *x509.Certificate */
 signer, _ := file.LoadSigner("rootCA.key")
 storage, _ := badger.New(badger.Options{InMemory: true})
 
+issuer, _ := inprocess.New(signer, caCert)
 ca, _ := nanoca.New(
 	logger,
-	inprocess.New(caCert, signer),
+	issuer,
 	nullauthorizer.New(),
 	storage,
 	"https://localhost:8443",

--- a/examples/nanomdm.go
+++ b/examples/nanomdm.go
@@ -56,9 +56,14 @@ func run() error {
 		return err
 	}
 
+	issuer, err := inprocess.New(signer, caCert)
+	if err != nil {
+		return err
+	}
+
 	ca, err := nanoca.New(
 		logger,
-		inprocess.New(caCert, signer),
+		issuer,
 		nullauthorizer.New(),
 		acmeStorage,
 		*baseURL,

--- a/handlers.go
+++ b/handlers.go
@@ -546,11 +546,12 @@ func (ca *CA) handleCertificate(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Replay-Nonce", nonce)
 	w.WriteHeader(http.StatusOK)
 
-	pemCert := pem.EncodeToMemory(&pem.Block{
-		Type:  "CERTIFICATE",
-		Bytes: cert.Raw,
-	})
-	_, _ = w.Write(pemCert)
+	for _, raw := range cert.ServedChain() {
+		if err := pem.Encode(w, &pem.Block{Type: "CERTIFICATE", Bytes: raw}); err != nil {
+			ca.logger.ErrorContext(ctx, "Failed to write certificate chain", "error", err)
+			return
+		}
+	}
 }
 
 func (ca *CA) writeJSONResponse(ctx context.Context, w http.ResponseWriter, statusCode int, data any, nonce string) {

--- a/integration_test.go
+++ b/integration_test.go
@@ -220,6 +220,21 @@ func TestDeviceAttestationFlow(t *testing.T) {
 			t.Logf("  Valid From: %s", parsedCert.NotBefore.Format(time.RFC3339))
 			t.Logf("  Valid Until: %s", parsedCert.NotAfter.Format(time.RFC3339))
 			t.Logf("  Certificate URL: %s", certURL)
+
+			if len(cert) != 2 {
+				t.Fatalf("Expected exactly two certificates (leaf + intermediate, self-signed root omitted), got %d", len(cert))
+			}
+
+			intermediateCert, err := x509.ParseCertificate(cert[1])
+			if err != nil {
+				t.Fatalf("Failed to parse intermediate certificate: %v", err)
+			}
+			if !intermediateCert.IsCA {
+				t.Error("Second certificate in chain should be a CA certificate")
+			}
+			if intermediateCert.Subject.CommonName != "Test Intermediate CA" {
+				t.Errorf("Intermediate common name = %v, want Test Intermediate CA", intermediateCert.Subject.CommonName)
+			}
 		} else {
 			t.Error("No certificate data returned")
 		}
@@ -259,14 +274,44 @@ func setupTestServerWithAttestation(t *testing.T) (*httptest.Server, *nanoca.CA)
 		t.Fatalf("Failed to parse CA certificate: %v", err)
 	}
 
+	intermKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("Failed to generate intermediate key: %v", err)
+	}
+
+	intermCertTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject: pkix.Name{
+			CommonName: "Test Intermediate CA",
+		},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+	}
+
+	intermCertDER, err := x509.CreateCertificate(rand.Reader, intermCertTemplate, caCert, &intermKey.PublicKey, signer)
+	if err != nil {
+		t.Fatalf("Failed to create intermediate CA certificate: %v", err)
+	}
+
+	intermCert, err := x509.ParseCertificate(intermCertDER)
+	if err != nil {
+		t.Fatalf("Failed to parse intermediate CA certificate: %v", err)
+	}
+
 	storage, err := store.New(store.Options{InMemory: true})
 	if err != nil {
 		t.Fatalf("Failed to create in-memory storage: %v", err)
 	}
 
+	issuer, err := inprocess.New(intermKey, intermCert, caCert)
+	if err != nil {
+		t.Fatalf("Failed to create certificate issuer: %v", err)
+	}
+
 	ca, err := nanoca.New(
 		slog.New(slog.DiscardHandler),
-		inprocess.New(caCert, signer),
+		issuer,
 		nullauthorizer.New(),
 		storage,
 		ts.URL,

--- a/issuers/inprocess/inprocess.go
+++ b/issuers/inprocess/inprocess.go
@@ -4,6 +4,7 @@ import (
 	"crypto"
 	"crypto/rand"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"time"
 
@@ -13,16 +14,35 @@ import (
 
 // Issuer implements the CertificateIssuer interface with a basic certificate generation approach
 type Issuer struct {
-	caCert *x509.Certificate
-	signer crypto.Signer
+	caCert   *x509.Certificate
+	signer   crypto.Signer
+	chainRaw [][]byte
 }
 
-// New creates a new in-process certificate issuer
-func New(caCert *x509.Certificate, signer crypto.Signer) *Issuer {
-	return &Issuer{
-		caCert: caCert,
-		signer: signer,
+// New creates a new in-process certificate issuer.
+//
+// issuerCert is the certificate whose key (signer) signs issued leaves. rest
+// continues the chain toward the root: rest[0] certifies issuerCert, and so on.
+// The full chain is stored on each issued certificate; the ACME certificate
+// response omits a trailing self-signed root at serve time per RFC 8555
+// Section 7.4.2 (see nanoca.Certificate.ServedChain).
+//
+//	New(signer, root)               // root signs leaves; serves leaf only
+//	New(signer, intermediate, root) // intermediate signs leaves; serves leaf + intermediate
+func New(signer crypto.Signer, issuerCert *x509.Certificate, rest ...*x509.Certificate) (*Issuer, error) {
+	chain := append([]*x509.Certificate{issuerCert}, rest...)
+	chainRaw := make([][]byte, len(chain))
+	for i, c := range chain {
+		if c == nil {
+			return nil, errors.New("issuing certificate chain contains a nil certificate")
+		}
+		chainRaw[i] = c.Raw
 	}
+	return &Issuer{
+		caCert:   issuerCert,
+		signer:   signer,
+		chainRaw: chainRaw,
+	}, nil
 }
 
 // IssueCertificate creates a certificate from CSR and device information
@@ -60,5 +80,6 @@ func (i *Issuer) IssueCertificate(csr *x509.CertificateRequest, deviceInfos []*n
 		Certificate:  x509Cert,
 		Raw:          certDER,
 		SerialNumber: x509Cert.SerialNumber.String(),
+		ChainRaw:     i.chainRaw,
 	}, nil
 }

--- a/issuers/inprocess/inprocess_test.go
+++ b/issuers/inprocess/inprocess_test.go
@@ -1,6 +1,7 @@
 package inprocess
 
 import (
+	"bytes"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -46,126 +47,253 @@ func createTestCA(t *testing.T) (*x509.Certificate, *ecdsa.PrivateKey) {
 	return cert, key
 }
 
+func createTestIntermediateCA(t *testing.T, parentCert *x509.Certificate, parentKey *ecdsa.PrivateKey) (*x509.Certificate, *ecdsa.PrivateKey) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("Failed to generate intermediate CA key: %v", err)
+	}
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject: pkix.Name{
+			CommonName:   "Test Intermediate CA",
+			Organization: []string{"Test CA Org"},
+		},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, parentCert, &key.PublicKey, parentKey)
+	if err != nil {
+		t.Fatalf("Failed to create intermediate CA certificate: %v", err)
+	}
+
+	cert, err := x509.ParseCertificate(certDER)
+	if err != nil {
+		t.Fatalf("Failed to parse intermediate CA certificate: %v", err)
+	}
+
+	return cert, key
+}
+
+func newTestCSR(t *testing.T, commonName string) *x509.CertificateRequest {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("Failed to generate CSR key: %v", err)
+	}
+
+	der, err := x509.CreateCertificateRequest(rand.Reader, &x509.CertificateRequest{
+		Subject: pkix.Name{CommonName: commonName},
+	}, key)
+	if err != nil {
+		t.Fatalf("Failed to create CSR: %v", err)
+	}
+
+	csr, err := x509.ParseCertificateRequest(der)
+	if err != nil {
+		t.Fatalf("Failed to parse CSR: %v", err)
+	}
+
+	return csr
+}
+
 func TestIssuer_IssueCertificate(t *testing.T) {
 	t.Parallel()
 
 	caCert, signer := createTestCA(t)
 
-	issuer := New(caCert, signer)
+	t.Run("self-signed root issuer stores root, serves leaf only", func(t *testing.T) {
+		issuer, err := New(signer, caCert)
+		if err != nil {
+			t.Fatalf("New() error = %v", err)
+		}
 
-	csrKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	if err != nil {
-		t.Fatalf("Failed to generate CSR key: %v", err)
-	}
+		cert, err := issuer.IssueCertificate(newTestCSR(t, "Test Device"), nil)
+		if err != nil {
+			t.Fatalf("IssueCertificate() error = %v", err)
+		}
 
-	csrTemplate := &x509.CertificateRequest{
-		Subject: pkix.Name{
-			CommonName:   "Test Device",
-			Organization: []string{"Test Org"},
-		},
-	}
+		// The full chain is stored, including the self-signed root.
+		if len(cert.ChainRaw) != 1 || !bytes.Equal(cert.ChainRaw[0], caCert.Raw) {
+			t.Fatalf("cert.ChainRaw should contain the root, got %d entries", len(cert.ChainRaw))
+		}
+		// The served chain omits the self-signed root: leaf only.
+		served := cert.ServedChain()
+		if len(served) != 1 || !bytes.Equal(served[0], cert.Raw) {
+			t.Fatalf("ServedChain should be the leaf only, got %d entries", len(served))
+		}
+	})
 
-	csrDER, err := x509.CreateCertificateRequest(rand.Reader, csrTemplate, csrKey)
-	if err != nil {
-		t.Fatalf("Failed to create CSR: %v", err)
-	}
+	t.Run("intermediate issuer stores full chain, serves leaf + intermediate", func(t *testing.T) {
+		intermCert, intermSigner := createTestIntermediateCA(t, caCert, signer)
+		issuer, err := New(intermSigner, intermCert, caCert)
+		if err != nil {
+			t.Fatalf("New() error = %v", err)
+		}
 
-	csr, err := x509.ParseCertificateRequest(csrDER)
-	if err != nil {
-		t.Fatalf("Failed to parse CSR: %v", err)
-	}
+		cert, err := issuer.IssueCertificate(newTestCSR(t, "Test Device With Chain"), nil)
+		if err != nil {
+			t.Fatalf("IssueCertificate() error = %v", err)
+		}
 
-	hwTypeOID := asn1.ObjectIdentifier{1, 2, 840, 113635, 100, 8, 9, 2}
-	deviceInfos := []*nanoca.DeviceInfo{
-		{
-			PermanentIdentifier: &nanoca.PermanentIdentifier{
-				Identifier: "device-123",
-				Assigner:   asn1.ObjectIdentifier{1, 2, 3, 4},
+		// The full chain is stored: intermediate then root.
+		if len(cert.ChainRaw) != 2 || !bytes.Equal(cert.ChainRaw[0], intermCert.Raw) || !bytes.Equal(cert.ChainRaw[1], caCert.Raw) {
+			t.Fatalf("cert.ChainRaw should be [intermediate, root], got %d entries", len(cert.ChainRaw))
+		}
+		// The served chain is leaf + intermediate; the trailing self-signed
+		// root is omitted per RFC 8555 §7.4.2.
+		served := cert.ServedChain()
+		if len(served) != 2 || !bytes.Equal(served[0], cert.Raw) || !bytes.Equal(served[1], intermCert.Raw) {
+			t.Fatalf("ServedChain should be [leaf, intermediate], got %d entries", len(served))
+		}
+		// The leaf must be signed by the intermediate, not the root.
+		if cert.Issuer.CommonName != intermCert.Subject.CommonName {
+			t.Errorf("leaf issuer CN = %q, want %q", cert.Issuer.CommonName, intermCert.Subject.CommonName)
+		}
+	})
+
+	t.Run("nil issuer certificate returns a construction error", func(t *testing.T) {
+		if _, err := New(signer, nil); err == nil {
+			t.Fatal("New() with a nil issuing certificate should error")
+		}
+	})
+
+	t.Run("nil entry in chain returns a construction error", func(t *testing.T) {
+		intermCert, intermSigner := createTestIntermediateCA(t, caCert, signer)
+
+		if _, err := New(intermSigner, intermCert, nil); err == nil {
+			t.Fatal("New() with a nil chain entry should error")
+		}
+	})
+
+	t.Run("non-self-signed trailing cert is kept in served chain", func(t *testing.T) {
+		intermCert, intermSigner := createTestIntermediateCA(t, caCert, signer)
+		// No root supplied: the trailing cert is the intermediate, which is
+		// not self-signed and therefore must be served.
+		issuer, err := New(intermSigner, intermCert)
+		if err != nil {
+			t.Fatalf("New() error = %v", err)
+		}
+
+		cert, err := issuer.IssueCertificate(newTestCSR(t, "Test Device No Root"), nil)
+		if err != nil {
+			t.Fatalf("IssueCertificate() error = %v", err)
+		}
+
+		if len(cert.ChainRaw) != 1 || !bytes.Equal(cert.ChainRaw[0], intermCert.Raw) {
+			t.Fatalf("cert.ChainRaw should contain exactly the intermediate certificate, got %d entries", len(cert.ChainRaw))
+		}
+		served := cert.ServedChain()
+		if len(served) != 2 || !bytes.Equal(served[0], cert.Raw) || !bytes.Equal(served[1], intermCert.Raw) {
+			t.Fatalf("ServedChain should be [leaf, intermediate], got %d entries", len(served))
+		}
+	})
+
+	t.Run("leaf carries SAN identifiers and client-auth key usage", func(t *testing.T) {
+		issuer, err := New(signer, caCert)
+		if err != nil {
+			t.Fatalf("New() error = %v", err)
+		}
+
+		csr := newTestCSR(t, "Test Device")
+
+		hwTypeOID := asn1.ObjectIdentifier{1, 2, 840, 113635, 100, 8, 9, 2}
+		deviceInfos := []*nanoca.DeviceInfo{
+			{
+				PermanentIdentifier: &nanoca.PermanentIdentifier{
+					Identifier: "device-123",
+					Assigner:   asn1.ObjectIdentifier{1, 2, 3, 4},
+				},
+				HardwareModule: &nanoca.HardwareModule{
+					Type:  hwTypeOID,
+					Value: []byte("UDID-ABC-123"),
+				},
 			},
-			HardwareModule: &nanoca.HardwareModule{
-				Type:  hwTypeOID,
-				Value: []byte("UDID-ABC-123"),
-			},
-		},
-	}
+		}
 
-	cert, err := issuer.IssueCertificate(csr, deviceInfos)
-	if err != nil {
-		t.Fatalf("IssueCertificate() error = %v", err)
-	}
-	if cert == nil {
-		t.Fatal("IssueCertificate() returned nil certificate")
-	}
+		cert, err := issuer.IssueCertificate(csr, deviceInfos)
+		if err != nil {
+			t.Fatalf("IssueCertificate() error = %v", err)
+		}
+		if cert == nil {
+			t.Fatal("IssueCertificate() returned nil certificate")
+		}
 
-	if cert.Certificate == nil {
-		t.Error("Certificate.Certificate is nil")
-	}
-	if len(cert.Raw) == 0 {
-		t.Error("Certificate.Raw is empty")
-	}
-	if cert.SerialNumber == "" {
-		t.Error("Certificate.SerialNumber is empty")
-	}
+		if cert.Certificate == nil {
+			t.Error("Certificate.Certificate is nil")
+		}
+		if len(cert.Raw) == 0 {
+			t.Error("Certificate.Raw is empty")
+		}
+		if cert.SerialNumber == "" {
+			t.Error("Certificate.SerialNumber is empty")
+		}
 
-	x509Cert := cert.Certificate
-	if x509Cert.Subject.CommonName != "Test Device" {
-		t.Errorf("Certificate CommonName = %v, want Test Device", x509Cert.Subject.CommonName)
-	}
-	if x509Cert.Issuer.CommonName != caCert.Subject.CommonName {
-		t.Errorf("Certificate Issuer CN = %v, want %v", x509Cert.Issuer.CommonName, caCert.Subject.CommonName)
-	}
-	if x509Cert.KeyUsage&x509.KeyUsageDigitalSignature == 0 {
-		t.Error("Certificate should have DigitalSignature key usage")
-	}
-	if x509Cert.KeyUsage&x509.KeyUsageKeyEncipherment == 0 {
-		t.Error("Certificate should have KeyEncipherment key usage")
-	}
-	if len(x509Cert.ExtKeyUsage) == 0 || x509Cert.ExtKeyUsage[0] != x509.ExtKeyUsageClientAuth {
-		t.Error("Certificate should have ClientAuth extended key usage")
-	}
+		x509Cert := cert.Certificate
+		if x509Cert.Subject.CommonName != "Test Device" {
+			t.Errorf("Certificate CommonName = %v, want Test Device", x509Cert.Subject.CommonName)
+		}
+		if x509Cert.Issuer.CommonName != caCert.Subject.CommonName {
+			t.Errorf("Certificate Issuer CN = %v, want %v", x509Cert.Issuer.CommonName, caCert.Subject.CommonName)
+		}
+		if x509Cert.KeyUsage&x509.KeyUsageDigitalSignature == 0 {
+			t.Error("Certificate should have DigitalSignature key usage")
+		}
+		if x509Cert.KeyUsage&x509.KeyUsageKeyEncipherment == 0 {
+			t.Error("Certificate should have KeyEncipherment key usage")
+		}
+		if len(x509Cert.ExtKeyUsage) == 0 || x509Cert.ExtKeyUsage[0] != x509.ExtKeyUsageClientAuth {
+			t.Error("Certificate should have ClientAuth extended key usage")
+		}
 
-	sanExt := certutil.FindExtension(x509Cert, certutil.OIDSubjectAltName)
-	if sanExt == nil {
-		t.Fatal("Certificate should have a SubjectAltName extension")
-	}
+		sanExt := certutil.FindExtension(x509Cert, certutil.OIDSubjectAltName)
+		if sanExt == nil {
+			t.Fatal("Certificate should have a SubjectAltName extension")
+		}
 
-	otherNames, err := certutil.ParseOtherNames(sanExt.Value)
-	if err != nil {
-		t.Fatalf("ParseOtherNames() error = %v", err)
-	}
-	foundPI, foundHM := false, false
-	for _, on := range otherNames {
-		if on.TypeID.Equal(certutil.OIDPermanentIdentifier) {
-			foundPI = true
-			pi, err := certutil.ParsePermanentIdentifier(on.Value)
-			if err != nil {
-				t.Fatalf("ParsePermanentIdentifier() error = %v", err)
+		otherNames, err := certutil.ParseOtherNames(sanExt.Value)
+		if err != nil {
+			t.Fatalf("ParseOtherNames() error = %v", err)
+		}
+		foundPI, foundHM := false, false
+		for _, on := range otherNames {
+			if on.TypeID.Equal(certutil.OIDPermanentIdentifier) {
+				foundPI = true
+				pi, err := certutil.ParsePermanentIdentifier(on.Value)
+				if err != nil {
+					t.Fatalf("ParsePermanentIdentifier() error = %v", err)
+				}
+				if pi.Identifier != "device-123" {
+					t.Errorf("PermanentIdentifier.Identifier = %q, want %q", pi.Identifier, "device-123")
+				}
+				if !pi.Assigner.Equal(asn1.ObjectIdentifier{1, 2, 3, 4}) {
+					t.Errorf("PermanentIdentifier.Assigner = %v, want %v", pi.Assigner, asn1.ObjectIdentifier{1, 2, 3, 4})
+				}
 			}
-			if pi.Identifier != "device-123" {
-				t.Errorf("PermanentIdentifier.Identifier = %q, want %q", pi.Identifier, "device-123")
-			}
-			if !pi.Assigner.Equal(asn1.ObjectIdentifier{1, 2, 3, 4}) {
-				t.Errorf("PermanentIdentifier.Assigner = %v, want %v", pi.Assigner, asn1.ObjectIdentifier{1, 2, 3, 4})
+			if on.TypeID.Equal(certutil.OIDHardwareModuleName) {
+				foundHM = true
+				hm, err := certutil.ParseHardwareModule(on.Value)
+				if err != nil {
+					t.Fatalf("ParseHardwareModule() error = %v", err)
+				}
+				if !hm.Type.Equal(hwTypeOID) {
+					t.Errorf("HardwareModule.Type = %v, want %v", hm.Type, hwTypeOID)
+				}
+				if string(hm.Value) != "UDID-ABC-123" {
+					t.Errorf("HardwareModule.Value = %q, want %q", hm.Value, "UDID-ABC-123")
+				}
 			}
 		}
-		if on.TypeID.Equal(certutil.OIDHardwareModuleName) {
-			foundHM = true
-			hm, err := certutil.ParseHardwareModule(on.Value)
-			if err != nil {
-				t.Fatalf("ParseHardwareModule() error = %v", err)
-			}
-			if !hm.Type.Equal(hwTypeOID) {
-				t.Errorf("HardwareModule.Type = %v, want %v", hm.Type, hwTypeOID)
-			}
-			if string(hm.Value) != "UDID-ABC-123" {
-				t.Errorf("HardwareModule.Value = %q, want %q", hm.Value, "UDID-ABC-123")
-			}
+		if !foundPI {
+			t.Error("SAN extension should contain a PermanentIdentifier otherName")
 		}
-	}
-	if !foundPI {
-		t.Error("SAN extension should contain a PermanentIdentifier otherName")
-	}
-	if !foundHM {
-		t.Error("SAN extension should contain a HardwareModuleName otherName")
-	}
+		if !foundHM {
+			t.Error("SAN extension should contain a HardwareModuleName otherName")
+		}
+	})
 }

--- a/testing/server.go
+++ b/testing/server.go
@@ -37,7 +37,10 @@ func run(logger *slog.Logger) error {
 		return fmt.Errorf("loading CA signer: %w", err)
 	}
 
-	certificateIssuer := inprocess.New(caCert, caSigner)
+	certificateIssuer, err := inprocess.New(caSigner, caCert)
+	if err != nil {
+		return fmt.Errorf("creating certificate issuer: %w", err)
+	}
 
 	storage, err := badger.New(badger.Options{InMemory: true})
 	if err != nil {

--- a/types.go
+++ b/types.go
@@ -1,6 +1,7 @@
 package nanoca
 
 import (
+	"bytes"
 	"crypto/x509"
 	"encoding/asn1"
 	"time"
@@ -47,10 +48,43 @@ type HardwareModule struct {
 	Value []byte
 }
 
+// Certificate holds an issued certificate and its full DER-encoded issuing
+// chain. ChainRaw is ordered issuer first and includes a trailing self-signed
+// root if one was supplied; it is persisted to storage as-is. The ACME
+// certificate response is built by ServedChain, which omits the root.
 type Certificate struct {
-	*x509.Certificate `json:"-"` // Exclude from JSON serialization
-	Raw               []byte     `json:"raw"`
-	SerialNumber      string     `json:"serialNumber"`
+	*x509.Certificate `json:"-"`
+	Raw               []byte   `json:"raw"`
+	SerialNumber      string   `json:"serialNumber"`
+	ChainRaw          [][]byte `json:"chainRaw,omitempty"`
+}
+
+// ServedChain returns the DER certificates for the ACME certificate response:
+// the leaf (Raw) followed by the issuing chain, with a trailing self-signed
+// root omitted per RFC 8555 Section 7.4.2 (clients already hold the root).
+func (c *Certificate) ServedChain() [][]byte {
+	chain := c.ChainRaw
+	if n := len(chain); n > 0 && isSelfSignedDER(chain[n-1]) {
+		chain = chain[:n-1]
+	}
+	return append([][]byte{c.Raw}, chain...)
+}
+
+// isSelfSignedDER reports whether a DER certificate is a self-signed root: its
+// subject equals its issuer and it is signed by its own key. The signature
+// check distinguishes a true root from a merely self-issued certificate (e.g. a
+// key-rollover bridge cert, subject==issuer but signed by a different key) that
+// must still be served. Unparseable input is treated as not self-signed, so it
+// is still served.
+func isSelfSignedDER(der []byte) bool {
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		return false
+	}
+	if !bytes.Equal(cert.RawSubject, cert.RawIssuer) {
+		return false
+	}
+	return cert.CheckSignature(cert.SignatureAlgorithm, cert.RawTBSCertificate, cert.Signature) == nil
 }
 
 type Directory struct {

--- a/types_test.go
+++ b/types_test.go
@@ -1,0 +1,99 @@
+package nanoca
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"testing"
+)
+
+// makeCert creates a certificate signed by parent (parent==nil/self for a
+// self-signed cert) and returns its DER. It is a minimal fixture for chain
+// presentation tests, not a realistic CA.
+func makeCert(t *testing.T, cn string, parent *x509.Certificate, parentKey *ecdsa.PrivateKey) ([]byte, *x509.Certificate, *ecdsa.PrivateKey) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: cn},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign,
+	}
+
+	signParent, signKey := template, key
+	if parent != nil {
+		signParent, signKey = parent, parentKey
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, template, signParent, &key.PublicKey, signKey)
+	if err != nil {
+		t.Fatalf("create cert %q: %v", cn, err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("parse cert %q: %v", cn, err)
+	}
+	return der, cert, key
+}
+
+func TestCertificateServedChain(t *testing.T) {
+	t.Parallel()
+
+	rootDER, root, rootKey := makeCert(t, "Root", nil, nil)
+	intermDER, _, _ := makeCert(t, "Intermediate", root, rootKey)
+	leafDER, _, _ := makeCert(t, "Leaf", root, rootKey)
+
+	tests := []struct {
+		name  string
+		chain [][]byte
+		want  [][]byte
+	}{
+		{"no chain serves leaf only", nil, [][]byte{leafDER}},
+		{"self-signed root omitted", [][]byte{rootDER}, [][]byte{leafDER}},
+		{"non-self-signed trailing kept", [][]byte{intermDER}, [][]byte{leafDER, intermDER}},
+		{"intermediate kept, root omitted", [][]byte{intermDER, rootDER}, [][]byte{leafDER, intermDER}},
+		{"unparseable trailing entry kept", [][]byte{[]byte("not-a-cert")}, [][]byte{leafDER, []byte("not-a-cert")}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cert := &Certificate{Raw: leafDER, ChainRaw: tc.chain}
+			got := cert.ServedChain()
+			if len(got) != len(tc.want) {
+				t.Fatalf("ServedChain() len = %d, want %d", len(got), len(tc.want))
+			}
+			for i := range got {
+				if !bytes.Equal(got[i], tc.want[i]) {
+					t.Errorf("ServedChain()[%d] mismatch", i)
+				}
+			}
+		})
+	}
+}
+
+func TestIsSelfSignedDER(t *testing.T) {
+	t.Parallel()
+
+	rootDER, root, rootKey := makeCert(t, "Root", nil, nil)
+	intermDER, _, _ := makeCert(t, "Intermediate", root, rootKey)
+
+	if !isSelfSignedDER(rootDER) {
+		t.Error("self-signed root should be detected as self-signed")
+	}
+	if isSelfSignedDER(intermDER) {
+		t.Error("intermediate should not be detected as self-signed")
+	}
+	if isSelfSignedDER([]byte("not-a-cert")) {
+		t.Error("unparseable DER should not be detected as self-signed")
+	}
+}


### PR DESCRIPTION
## Summary

`handleCertificate` previously returned only the leaf certificate. RFC 8555 §7.4.2 requires the full chain, which breaks clients using nanoca as an intermediate CA since they cannot build a trust path from the leaf alone.

This change makes the in-process issuer accept an optional variadic `chain` argument. When present, the ACME certificate endpoint returns the leaf followed by each chain certificate as a single `application/pem-certificate-chain` response.

## Compatibility

- `inprocess.New` changes signature from `New(caCert, signer)` to `New(signer, chain ...*x509.Certificate)`. The argument order is swapped, so this is a breaking change: existing callers must update to `inprocess.New(signer, caCert)`. Callers passing no chain otherwise behave identically.
- No change to the `CertificateIssuer` or `Storage` interface signatures.
- `testing/server.go` and `examples/nanomdm.go` are updated to the new argument order.

## Notes

- `ChainRaw` (`[][]byte`) is the chain served after the leaf; it is persisted to storage and is what the ACME certificate endpoint returns.

## Test plan

- `go build ./...` passes
- `go test ./...` passes
- `issuers/inprocess` tests cover the no-chain (existing behavior preserved) and intermediate-chain (two entries, correct order) cases
- `integration_test.go` verifies the certificate endpoint returns multiple PEM blocks when a chain is present, and that the second block parses as a valid CA certificate

---

Split out from #4 (this is one of two independent PRs replacing it). The remote signing oracle is in a separate PR.

