### PR TITLE
feat: add remote HTTP signing oracle signer

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,36 @@ defer ca.Close()
 mux := http.NewServeMux()
 mux.Handle("/", ca.Handler())
 ```
+
+### Certificate chain serving
+
+When nanoca is deployed as an intermediate CA, ACME clients need the full certificate chain to build a trust path. Pass the chain to the in-process issuer after the signer argument:
+
+```go
+// intermCert is the issuing intermediate, rootCert is the root CA.
+// Order matters: issuer of the leaf first, then its issuer, up toward the root.
+issuer := inprocess.New(intermCert, intermSigner, intermCert, rootCert)
+```
+
+The ACME certificate endpoint will return the leaf followed by each chain certificate as a PEM-encoded `application/pem-certificate-chain` response per RFC 8555 Section 7.4.2. Callers that don't pass a chain get the previous behavior (leaf only).
+
+### Remote signing oracle
+
+The `signers/remote` package provides a `crypto.Signer` that delegates signing to an external HTTP service, allowing the CA private key to live in an HSM, cloud KMS, or any custom signing service.
+
+```go
+import "github.com/brandonweeks/nanoca/signers/remote"
+
+signer, err := remote.New(
+	"https://signer.internal:8443",  // oracle URL (must be HTTPS)
+	"bearer-token",                   // Authorization header value
+	publicKeyPEM,                     // PEM-encoded ECDSA public key
+)
+```
+
+The oracle protocol is a single endpoint:
+
+- `POST /sign` with `Authorization: Bearer <token>` and JSON body `{"digest": "<base64>", "hash": "SHA-256"}`
+- Response: `{"signature": "<base64-DER>"}`
+
+The signer verifies every signature returned by the oracle against the known public key before passing it to the caller. Plain HTTP is rejected unless the oracle is on a loopback address.

--- a/signers/remote/remote.go
+++ b/signers/remote/remote.go
@@ -1,0 +1,192 @@
+// Package remote provides a crypto.Signer implementation that delegates
+// signing operations to an authenticated HTTP signing oracle.
+//
+// The oracle protocol is minimal:
+//
+//	POST /sign
+//	Authorization: Bearer <token>
+//	Content-Type: application/json
+//
+//	Request:  {"digest": "<base64>", "hash": "<SHA-256|SHA-384|SHA-512>"}
+//	Response: {"signature": "<base64-DER>"}
+//
+// The digest field contains the pre-hashed digest as produced by
+// crypto/x509 internals — callers must not hash again.
+// The signature field must be a DER-encoded ASN.1 ECDSA signature
+// (not IEEE P1363 / raw r||s concatenation).
+package remote
+
+import (
+	"bytes"
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+	"unicode"
+)
+
+// Signer delegates crypto.Signer operations to a remote HTTP signing oracle.
+type Signer struct {
+	signURL    string
+	authToken  string
+	publicKey  crypto.PublicKey
+	httpClient *http.Client
+}
+
+// New creates a remote signer.
+//
+// oracleURL is the base URL of the signing oracle (e.g. https://signer.example.com).
+// The URL must use HTTPS; plain HTTP is only permitted for loopback addresses
+// (localhost, 127.0.0.1, ::1) to support development and testing.
+// authToken is sent as a Bearer token in the Authorization header.
+// publicKeyPEM is the PKIX PEM-encoded public key corresponding to the
+// private key held by the oracle. It is used to satisfy crypto.Signer.Public()
+// and is never sent to the oracle. After each signing operation, the returned
+// signature is verified against this key before being returned to the caller.
+func New(oracleURL, authToken, publicKeyPEM string) (*Signer, error) {
+	if err := validateOracleURL(oracleURL); err != nil {
+		return nil, fmt.Errorf("remote signer: %w", err)
+	}
+	signURL, err := url.JoinPath(oracleURL, "sign")
+	if err != nil {
+		return nil, fmt.Errorf("remote signer: building oracle URL: %w", err)
+	}
+	pub, err := parsePublicKeyPEM(publicKeyPEM)
+	if err != nil {
+		return nil, fmt.Errorf("remote signer: parsing public key: %w", err)
+	}
+	return &Signer{
+		signURL:   signURL,
+		authToken: authToken,
+		publicKey: pub,
+		httpClient: &http.Client{
+			Timeout: 10 * time.Second,
+		},
+	}, nil
+}
+
+// Public returns the public key corresponding to the private key held by the oracle.
+func (s *Signer) Public() crypto.PublicKey { return s.publicKey }
+
+type signRequest struct {
+	Digest string `json:"digest"`
+	Hash   string `json:"hash"`
+}
+
+type signResponse struct {
+	Signature string `json:"signature"`
+}
+
+// Sign sends the digest to the oracle and returns a DER-encoded signature.
+// digest is the pre-hashed digest as passed by crypto/x509 internals.
+// The oracle is responsible for not hashing again.
+//
+// Note: the crypto.Signer interface does not accept a context, so this method
+// uses context.Background(). Cancellation relies on the http.Client timeout.
+func (s *Signer) Sign(_ io.Reader, digest []byte, opts crypto.SignerOpts) ([]byte, error) {
+	if opts == nil {
+		return nil, errors.New("remote signer: signer opts are required")
+	}
+
+	reqBody, err := json.Marshal(signRequest{
+		Digest: base64.StdEncoding.EncodeToString(digest),
+		Hash:   opts.HashFunc().String(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("remote signer: marshalling request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, s.signURL, bytes.NewReader(reqBody))
+	if err != nil {
+		return nil, fmt.Errorf("remote signer: building request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+s.authToken)
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("remote signer: oracle request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	const maxResponseSize = 1 << 20 // 1MB
+	const maxErrorSize = 4096       // 4KB
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorSize))
+		return nil, fmt.Errorf("remote signer: oracle returned %d: %s", resp.StatusCode, sanitizeErrorBody(body))
+	}
+
+	var sr signResponse
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxResponseSize)).Decode(&sr); err != nil {
+		return nil, fmt.Errorf("remote signer: decoding oracle response: %w", err)
+	}
+
+	sig, err := base64.StdEncoding.DecodeString(sr.Signature)
+	if err != nil {
+		return nil, fmt.Errorf("remote signer: decoding signature bytes: %w", err)
+	}
+
+	ecPub, ok := s.publicKey.(*ecdsa.PublicKey)
+	if !ok {
+		return nil, errors.New("remote signer: public key is not ECDSA")
+	}
+	if !ecdsa.VerifyASN1(ecPub, digest, sig) {
+		return nil, errors.New("remote signer: oracle returned invalid signature")
+	}
+
+	return sig, nil
+}
+
+// sanitizeErrorBody strips control characters from oracle error responses
+// to prevent log injection.
+func sanitizeErrorBody(body []byte) string {
+	return strings.Map(func(r rune) rune {
+		if unicode.IsControl(r) && r != ' ' {
+			return '?'
+		}
+		return r
+	}, string(body))
+}
+
+func validateOracleURL(oracleURL string) error {
+	u, err := url.Parse(oracleURL)
+	if err != nil {
+		return fmt.Errorf("invalid oracle URL: %w", err)
+	}
+	if u.Scheme == "https" {
+		return nil
+	}
+	if u.Scheme == "http" {
+		host := u.Hostname()
+		if host == "localhost" || host == "127.0.0.1" || host == "::1" {
+			return nil
+		}
+	}
+	return errors.New("oracle URL must use HTTPS (plain HTTP is only allowed for loopback addresses)")
+}
+
+func parsePublicKeyPEM(pemStr string) (crypto.PublicKey, error) {
+	block, _ := pem.Decode([]byte(pemStr))
+	if block == nil {
+		return nil, errors.New("no PEM block found")
+	}
+	key, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parsing PKIX public key: %w", err)
+	}
+	if _, ok := key.(*ecdsa.PublicKey); !ok {
+		return nil, fmt.Errorf("expected ECDSA public key, got %T", key)
+	}
+	return key, nil
+}

--- a/signers/remote/remote_test.go
+++ b/signers/remote/remote_test.go
@@ -1,0 +1,331 @@
+package remote
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func generateP256PEM(t *testing.T) (string, *ecdsa.PrivateKey) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+	der, err := x509.MarshalPKIXPublicKey(&key.PublicKey)
+	if err != nil {
+		t.Fatalf("failed to marshal public key: %v", err)
+	}
+	return string(pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der})), key
+}
+
+func generateRSAPEM(t *testing.T) string {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate RSA key: %v", err)
+	}
+	der, err := x509.MarshalPKIXPublicKey(&key.PublicKey)
+	if err != nil {
+		t.Fatalf("failed to marshal RSA public key: %v", err)
+	}
+	return string(pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der}))
+}
+
+func TestNew_validKey(t *testing.T) {
+	pemStr, _ := generateP256PEM(t)
+	signer, err := New("http://localhost:8080", "token", pemStr)
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+	if signer.Public() == nil {
+		t.Fatal("Public() returned nil")
+	}
+}
+
+func TestNew_invalidKey(t *testing.T) {
+	_, err := New("http://localhost:8080", "token", "garbage")
+	if err == nil {
+		t.Fatal("New() should have failed with garbage PEM")
+	}
+}
+
+func TestNew_wrongKeyType(t *testing.T) {
+	pemStr := generateRSAPEM(t)
+	_, err := New("http://localhost:8080", "token", pemStr)
+	if err == nil {
+		t.Fatal("New() should have failed with RSA key")
+	}
+	if !strings.Contains(err.Error(), "expected ECDSA public key") {
+		t.Errorf("expected error message to contain 'expected ECDSA public key', got: %v", err)
+	}
+}
+
+func TestSign_success(t *testing.T) {
+	pemStr, key := generateP256PEM(t)
+	digest := []byte("this is a digest")
+	token := "secret-token"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/sign" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Header.Get("Authorization") != "Bearer "+token {
+			t.Errorf("unexpected auth header: %s", r.Header.Get("Authorization"))
+		}
+		var req signRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("failed to decode request: %v", err)
+		}
+		decodedDigest, _ := base64.StdEncoding.DecodeString(req.Digest)
+		if string(decodedDigest) != string(digest) {
+			t.Errorf("digest mismatch: %s != %s", string(decodedDigest), string(digest))
+		}
+
+		sig, err := key.Sign(rand.Reader, decodedDigest, crypto.SHA256)
+		if err != nil {
+			t.Errorf("failed to sign: %v", err)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(signResponse{
+			Signature: base64.StdEncoding.EncodeToString(sig),
+		})
+	}))
+	defer ts.Close()
+
+	signer, _ := New(ts.URL, token, pemStr)
+	sig, err := signer.Sign(nil, digest, crypto.SHA256)
+	if err != nil {
+		t.Fatalf("Sign() failed: %v", err)
+	}
+	if len(sig) == 0 {
+		t.Fatal("Sign() returned empty signature")
+	}
+}
+
+func TestSign_invalidSignature(t *testing.T) {
+	pemStr, _ := generateP256PEM(t)
+	// Use a different key to produce a valid DER signature that won't verify
+	// against the public key the signer was constructed with.
+	wrongKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate wrong key: %v", err)
+	}
+	digest := []byte("this is a digest")
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		sig, sigErr := wrongKey.Sign(rand.Reader, digest, crypto.SHA256)
+		if sigErr != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(signResponse{
+			Signature: base64.StdEncoding.EncodeToString(sig),
+		})
+	}))
+	defer ts.Close()
+
+	signer, _ := New(ts.URL, "token", pemStr)
+	_, err = signer.Sign(nil, digest, crypto.SHA256)
+	if err == nil {
+		t.Fatal("Sign() should have failed with wrong-key signature")
+	}
+	if !strings.Contains(err.Error(), "oracle returned invalid signature") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestSign_oracleError(t *testing.T) {
+	pemStr, _ := generateP256PEM(t)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("oracle error"))
+	}))
+	defer ts.Close()
+
+	signer, _ := New(ts.URL, "token", pemStr)
+	_, err := signer.Sign(nil, []byte("digest"), crypto.SHA256)
+	if err == nil {
+		t.Fatal("Sign() should have failed")
+	}
+	if !strings.Contains(err.Error(), "oracle returned 500") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestSign_oracleUnauthorized(t *testing.T) {
+	pemStr, _ := generateP256PEM(t)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte("unauthorized"))
+	}))
+	defer ts.Close()
+
+	signer, _ := New(ts.URL, "token", pemStr)
+	_, err := signer.Sign(nil, []byte("digest"), crypto.SHA256)
+	if err == nil {
+		t.Fatal("Sign() should have failed")
+	}
+	if !strings.Contains(err.Error(), "oracle returned 401") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestSign_networkError(t *testing.T) {
+	pemStr, _ := generateP256PEM(t)
+	// Unreachable URL
+	signer, _ := New("http://localhost:1", "token", pemStr)
+	_, err := signer.Sign(nil, []byte("digest"), crypto.SHA256)
+	if err == nil {
+		t.Fatal("Sign() should have failed")
+	}
+	if !strings.Contains(err.Error(), "oracle request failed") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestSign_malformedResponse(t *testing.T) {
+	pemStr, _ := generateP256PEM(t)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("not json"))
+	}))
+	defer ts.Close()
+
+	signer, _ := New(ts.URL, "token", pemStr)
+	_, err := signer.Sign(nil, []byte("digest"), crypto.SHA256)
+	if err == nil {
+		t.Fatal("Sign() should have failed")
+	}
+	if !strings.Contains(err.Error(), "decoding oracle response") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestSign_invalidBase64Signature(t *testing.T) {
+	pemStr, _ := generateP256PEM(t)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(signResponse{
+			Signature: "not-valid-base64!@#$",
+		})
+	}))
+	defer ts.Close()
+
+	signer, _ := New(ts.URL, "token", pemStr)
+	_, err := signer.Sign(nil, []byte("digest"), crypto.SHA256)
+	if err == nil {
+		t.Fatal("Sign() should have failed with invalid base64 signature")
+	}
+	if !strings.Contains(err.Error(), "decoding signature bytes") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestSign_responseTooLarge(t *testing.T) {
+	pemStr, _ := generateP256PEM(t)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Send a response larger than 1MB
+		largeSignature := strings.Repeat("A", 1<<20+100)
+		_ = json.NewEncoder(w).Encode(signResponse{
+			Signature: largeSignature,
+		})
+	}))
+	defer ts.Close()
+
+	signer, _ := New(ts.URL, "token", pemStr)
+	_, err := signer.Sign(nil, []byte("digest"), crypto.SHA256)
+	if err == nil {
+		t.Fatal("Sign() should have failed due to large response")
+	}
+	if !strings.Contains(err.Error(), "decoding oracle response") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestSign_errorTooLarge(t *testing.T) {
+	pemStr, _ := generateP256PEM(t)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		// Send an error body larger than 4KB
+		_, _ = w.Write([]byte(strings.Repeat("E", 8192)))
+	}))
+	defer ts.Close()
+
+	signer, _ := New(ts.URL, "token", pemStr)
+	_, err := signer.Sign(nil, []byte("digest"), crypto.SHA256)
+	if err == nil {
+		t.Fatal("Sign() should have failed")
+	}
+	// The implementation uses LimitReader(resp.Body, 4096), so the body read is limited.
+	if !strings.Contains(err.Error(), "oracle returned 500") {
+		t.Errorf("unexpected error: %v", err)
+	}
+	errStr := err.Error()
+	if len(errStr) > 5000 { // 4096 + some overhead for the message prefix
+		t.Errorf("error message too long: %d bytes", len(errStr))
+	}
+}
+
+func TestNew_rejectsPlaintextHTTP(t *testing.T) {
+	pemStr, _ := generateP256PEM(t)
+	_, err := New("http://signer.example.com", "token", pemStr)
+	if err == nil {
+		t.Fatal("New() should reject plain HTTP to non-loopback address")
+	}
+	if !strings.Contains(err.Error(), "must use HTTPS") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestNew_allowsHTTPLoopback(t *testing.T) {
+	pemStr, _ := generateP256PEM(t)
+	for _, addr := range []string{"localhost:8080", "127.0.0.1:8080", "[::1]:8080"} {
+		_, err := New("http://"+addr, "token", pemStr)
+		if err != nil {
+			t.Errorf("New() should allow HTTP to %s, got: %v", addr, err)
+		}
+	}
+}
+
+func TestNew_allowsHTTPS(t *testing.T) {
+	pemStr, _ := generateP256PEM(t)
+	_, err := New("https://signer.example.com", "token", pemStr)
+	if err != nil {
+		t.Errorf("New() should allow HTTPS, got: %v", err)
+	}
+}
+
+func TestSign_errorBodySanitized(t *testing.T) {
+	pemStr, _ := generateP256PEM(t)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		// Include control characters that could be used for log injection
+		_, _ = w.Write([]byte("error\ninjected-line\r\x00hidden"))
+	}))
+	defer ts.Close()
+
+	signer, _ := New(ts.URL, "token", pemStr)
+	_, err := signer.Sign(nil, []byte("digest"), crypto.SHA256)
+	if err == nil {
+		t.Fatal("Sign() should have failed")
+	}
+	errMsg := err.Error()
+	if strings.Contains(errMsg, "\n") || strings.Contains(errMsg, "\r") || strings.Contains(errMsg, "\x00") {
+		t.Errorf("error message contains unsanitized control characters: %q", errMsg)
+	}
+	if !strings.Contains(errMsg, "error?injected-line") {
+		t.Errorf("expected sanitized error body, got: %q", errMsg)
+	}
+}


### PR DESCRIPTION
## Summary

The only signer implementation was `signers/file`, which requires the CA private key on disk at runtime. This adds `signers/remote`: a `crypto.Signer` that delegates signing to an authenticated HTTP signing oracle, so the key can live in an HSM, cloud KMS, or a custom signing service without forking the core.

The oracle protocol is intentionally minimal:

```
POST /sign
Authorization: Bearer <token>
Content-Type: application/json

Request:  {"digest": "<base64>", "hash": "<SHA-256|SHA-384|SHA-512>"}
Response: {"signature": "<base64-DER>"}
```

## No new dependencies

`signers/remote` imports **stdlib only** — no provider SDKs (AWS/GCP/etc.). The caller supplies a URL and a bearer token; what sits behind that URL is not nanoca's concern. `go.mod` is unchanged.

## Security hardening

- Signatures are verified against the known public key after every oracle response, catching misconfiguration or oracle compromise before a bad certificate is issued.
- Oracle URL must be HTTPS; plain HTTP is permitted only for loopback addresses.
- Oracle error response bodies are sanitized to strip control characters before inclusion in error messages (log-injection prevention).
- Response bodies are size-limited (1 MB success, 4 KB error).

## Test plan

- `go build ./...` passes
- `go test ./...` passes
- `signers/remote` tests cover construction (valid / invalid / wrong-key-type PEM) and signing (success, oracle 5xx, 401, network error, malformed JSON, invalid base64) against an `httptest.Server`

---

Split out from #4 (this is one of two independent PRs replacing it). Certificate chain serving is in a separate PR.
