### PR TITLE
fix(handlers): index accounts by JWK thumbprint

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -159,16 +159,10 @@ func (ca *CA) handleNewAccount(w http.ResponseWriter, r *http.Request) {
 	accountID := ca.generateAccountID()
 	ctx = WithAccountID(ctx, accountID)
 
-	jwkBytes, err := json.Marshal(postData.jwk)
-	if err != nil {
-		ca.writeProblem(ctx, w, InternalServerError("Failed to serialize account key"))
-		return
-	}
-
 	account := &Account{
 		ID:                   accountID,
 		Key:                  postData.jwk,
-		KeyBytes:             jwkBytes, // Store the actual JWK JSON data
+		KeyThumbprint:        keyHash,
 		Status:               "valid",
 		Contact:              accountReq.Contact,
 		TermsOfServiceAgreed: accountReq.TermsOfServiceAgreed,
@@ -644,7 +638,7 @@ func (ca *CA) computeJWKHash(jwk *jose.JSONWebKey) (string, error) {
 		return "", fmt.Errorf("failed to compute JWK thumbprint: %w", err)
 	}
 
-	return string(thumbprint), nil
+	return base64.RawURLEncoding.EncodeToString(thumbprint), nil
 }
 
 func (ca *CA) createOrder(ctx context.Context, accountID string, orderReq OrderRequest) (*Order, error) {

--- a/handlers_flow_test.go
+++ b/handlers_flow_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"net/http/httptest"
 	"testing"
 
@@ -159,8 +160,10 @@ func TestDuplicateRegistrationReturnsExisting(t *testing.T) {
 	if _, err := newClient().Register(t.Context(), &acme.Account{}, acme.AcceptTOS); err != nil {
 		t.Fatalf("first register failed: %v", err)
 	}
-	if _, err := newClient().Register(t.Context(), &acme.Account{}, acme.AcceptTOS); err != nil {
-		t.Fatalf("second register failed: %v", err)
+	// x/crypto/acme returns ErrAccountAlreadyExists on a 200 from newAccount;
+	// a nil error means the server minted a duplicate account (201).
+	if _, err := newClient().Register(t.Context(), &acme.Account{}, acme.AcceptTOS); !errors.Is(err, acme.ErrAccountAlreadyExists) {
+		t.Fatalf("second register error = %v, want ErrAccountAlreadyExists", err)
 	}
 }
 

--- a/storage/badger/storage.go
+++ b/storage/badger/storage.go
@@ -135,8 +135,8 @@ func putAccount(txn *badger.Txn, account *nanoca.Account) error {
 		return err
 	}
 
-	if len(account.KeyBytes) > 0 {
-		return txn.Set(accountKeyLookupKey(string(account.KeyBytes)), []byte(account.ID))
+	if account.KeyThumbprint != "" {
+		return txn.Set(accountKeyLookupKey(account.KeyThumbprint), []byte(account.ID))
 	}
 
 	return nil

--- a/storage/badger/storage_test.go
+++ b/storage/badger/storage_test.go
@@ -113,10 +113,10 @@ func TestStorage_AccountOperations(t *testing.T) {
 
 	ctx := t.Context()
 	account := &nanoca.Account{
-		ID:       "test-account-123",
-		Contact:  []string{"mailto:test@example.com"},
-		Status:   "valid",
-		KeyBytes: []byte("key-thumbprint-hash"),
+		ID:            "test-account-123",
+		Contact:       []string{"mailto:test@example.com"},
+		Status:        "valid",
+		KeyThumbprint: "key-thumbprint-hash",
 	}
 
 	err := storage.CreateAccount(ctx, account)
@@ -132,7 +132,7 @@ func TestStorage_AccountOperations(t *testing.T) {
 		t.Errorf("GetAccount() ID = %v, want %v", retrieved.ID, account.ID)
 	}
 
-	retrieved, err = storage.GetAccountByKey(ctx, string(account.KeyBytes))
+	retrieved, err = storage.GetAccountByKey(ctx, account.KeyThumbprint)
 	if err != nil {
 		t.Errorf("GetAccountByKey() error = %v", err)
 	}

--- a/types.go
+++ b/types.go
@@ -109,9 +109,9 @@ type Nonce struct {
 }
 
 type Account struct {
-	ID                   string           `json:"id"`                 // Include in storage
-	Key                  *jose.JSONWebKey `json:"key,omitempty"`      // Include in storage
-	KeyBytes             []byte           `json:"keyBytes,omitempty"` // Include in storage
+	ID                   string           `json:"id"`                      // Include in storage
+	Key                  *jose.JSONWebKey `json:"key,omitempty"`           // Include in storage
+	KeyThumbprint        string           `json:"keyThumbprint,omitempty"` // Include in storage
 	Status               string           `json:"status"`
 	Contact              []string         `json:"contact,omitempty"`
 	TermsOfServiceAgreed bool             `json:"termsOfServiceAgreed,omitempty"`


### PR DESCRIPTION
handleNewAccount looked up existing accounts by SHA-256 thumbprint but stored the raw JWK JSON as the lookup key, so re-registering a key always created a duplicate account. Store the base64url thumbprint on the account and index by it.