### PR TITLE
feat(storage): export sentinel errors, harden finalize and challenge races

### DIFF
--- a/ca.go
+++ b/ca.go
@@ -18,9 +18,10 @@ type CA struct {
 	observers         []IssuanceObserver
 	verifiers         map[string]AttestationVerifier
 
-	baseURL     string
-	prefix      string
-	nonceExpiry time.Duration
+	baseURL          string
+	prefix           string
+	nonceExpiry      time.Duration
+	reservationLease time.Duration
 
 	storage Storage
 }
@@ -52,6 +53,16 @@ func WithPrefix(prefix string) Option {
 	}
 }
 
+// WithReservationLease sets how long a finalize or challenge-validation
+// reservation is honored before another request may reclaim it. It bounds
+// how long a crashed instance can hold an order or challenge in processing,
+// and must exceed the worst-case verifier, authorizer, and issuer latency.
+func WithReservationLease(d time.Duration) Option {
+	return func(ca *CA) {
+		ca.reservationLease = d
+	}
+}
+
 func New(logger *slog.Logger, issuer CertificateIssuer, authorizer Authorizer, storage Storage, baseURL string, opts ...Option) (*CA, error) {
 	if logger == nil {
 		return nil, errors.New("logger is required")
@@ -80,6 +91,7 @@ func New(logger *slog.Logger, issuer CertificateIssuer, authorizer Authorizer, s
 		storage:           storage,
 		baseURL:           baseURL,
 		nonceExpiry:       time.Hour,
+		reservationLease:  time.Minute,
 		verifiers:         make(map[string]AttestationVerifier),
 	}
 
@@ -89,6 +101,12 @@ func New(logger *slog.Logger, issuer CertificateIssuer, authorizer Authorizer, s
 
 	if len(ca.verifiers) == 0 {
 		return nil, errors.New("at least one attestation verifier must be registered")
+	}
+
+	// A nonpositive lease makes every reservation expired at birth, so
+	// concurrent finalizes would each reclaim the other's and both sign.
+	if ca.reservationLease <= 0 {
+		return nil, errors.New("reservation lease must be positive")
 	}
 
 	return ca, nil

--- a/ca_test.go
+++ b/ca_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509"
 	"log/slog"
 	"testing"
+	"time"
 
 	"github.com/brandonweeks/nanoca"
 	nullauthorizer "github.com/brandonweeks/nanoca/authorizers/null"
@@ -61,6 +62,28 @@ func TestNewValidation(t *testing.T) {
 				t.Error("New() error = nil, want error")
 			}
 		})
+	}
+}
+
+// A nonpositive lease makes every reservation expired at birth: concurrent
+// finalizes each reclaim the other's reservation and both sign, silently
+// voiding the exclusivity the reservation exists to provide.
+func TestNewRejectsNonpositiveReservationLease(t *testing.T) {
+	t.Parallel()
+
+	for _, d := range []time.Duration{0, -time.Minute} {
+		_, err := nanoca.New(
+			slog.New(slog.DiscardHandler),
+			stubIssuer{},
+			nullauthorizer.New(),
+			newTestStorage(t),
+			"https://ca.example",
+			nanoca.WithVerifier(null.New()),
+			nanoca.WithReservationLease(d),
+		)
+		if err == nil {
+			t.Errorf("New(WithReservationLease(%v)) error = nil, want error", d)
+		}
 	}
 }
 

--- a/handlers.go
+++ b/handlers.go
@@ -34,30 +34,21 @@ type authenticatedPOST struct {
 // or by looking it up in a database based on the input.
 type keyExtractor func(*http.Request, *jose.JSONWebSignature) (*jose.JSONWebKey, *Problem)
 
-var (
-	ErrNonceNotFound = errors.New("nonce not found")
-	ErrNonceExpired  = errors.New("nonce expired")
-)
-
-type NonceValidationError struct {
-	Err error
+// lookupProblem maps a storage lookup failure to a client-facing problem: a
+// missing object is the client's error, anything else is the server's.
+func lookupProblem(err error, resource string) *Problem {
+	if errors.Is(err, ErrNotFound) {
+		return Malformed(resource + " not found")
+	}
+	return InternalServerError("Failed to get " + strings.ToLower(resource))
 }
 
-func (e *NonceValidationError) Error() string {
-	return fmt.Sprintf("nonce validation failed: %v", e.Err)
-}
-
-func (e *NonceValidationError) Unwrap() error {
-	return e.Err
-}
-
-func (e *NonceValidationError) Is(target error) bool {
-	return errors.Is(e.Err, target)
-}
-
-func isNonceError(err error) bool {
-	var nonceValidationErr *NonceValidationError
-	return errors.As(err, &nonceValidationErr)
+// isFenceRejection reports whether a guarded or fenced storage write was
+// rejected because another request has settled the record; the winner's
+// result stands. Missing either sentinel would misread a lost race as a
+// backend failure.
+func isFenceRejection(err error) bool {
+	return errors.Is(err, ErrReserved) || errors.Is(err, ErrStatusMismatch)
 }
 
 func (ca *CA) handleDirectory(w http.ResponseWriter, r *http.Request) {
@@ -130,25 +121,19 @@ func (ca *CA) handleNewAccount(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	keyHash, err := ca.computeJWKHash(postData.jwk)
+	keyThumbprint, err := jwkThumbprint(postData.jwk)
 	if err != nil {
 		ca.writeProblem(ctx, w, InternalServerError("Failed to process key"))
 		return
 	}
 
-	existingAccount, err := ca.storage.GetAccountByKey(ctx, keyHash)
+	existingAccount, err := ca.storage.GetAccountByKey(ctx, keyThumbprint)
+	if err != nil && !errors.Is(err, ErrNotFound) {
+		ca.writeProblem(ctx, w, InternalServerError("Failed to look up account"))
+		return
+	}
 	if err == nil {
-		ctx = WithAccountID(ctx, existingAccount.ID)
-		if existingAccount.Orders == "" {
-			existingAccount.Orders = ca.url(fmt.Sprintf("/account/%s/orders", existingAccount.ID))
-			if err := ca.storage.UpdateAccount(ctx, existingAccount); err != nil {
-				ca.logger.ErrorContext(ctx, "Failed to update account orders URL", "error", err)
-			}
-		}
-
-		accountURL := ca.url(fmt.Sprintf("/account/%s", existingAccount.ID))
-		w.Header().Set("Location", accountURL)
-		ca.writeJSONResponseWithNonce(ctx, w, http.StatusOK, existingAccount)
+		ca.writeExistingAccount(ctx, w, existingAccount)
 		return
 	}
 
@@ -163,7 +148,7 @@ func (ca *CA) handleNewAccount(w http.ResponseWriter, r *http.Request) {
 	account := &Account{
 		ID:                   accountID,
 		Key:                  postData.jwk,
-		KeyThumbprint:        keyHash,
+		KeyThumbprint:        keyThumbprint,
 		Status:               "valid",
 		Contact:              accountReq.Contact,
 		TermsOfServiceAgreed: accountReq.TermsOfServiceAgreed,
@@ -172,6 +157,13 @@ func (ca *CA) handleNewAccount(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := ca.storage.CreateAccount(ctx, account); err != nil {
+		// Lost a race with a concurrent registration; return the winner.
+		if errors.Is(err, ErrAccountExists) {
+			if existing, err := ca.storage.GetAccountByKey(ctx, keyThumbprint); err == nil {
+				ca.writeExistingAccount(ctx, w, existing)
+				return
+			}
+		}
 		ca.writeProblem(ctx, w, InternalServerError("Failed to create account"))
 		return
 	}
@@ -181,6 +173,21 @@ func (ca *CA) handleNewAccount(w http.ResponseWriter, r *http.Request) {
 	accountURL := ca.url(fmt.Sprintf("/account/%s", accountID))
 	w.Header().Set("Location", accountURL)
 	ca.writeJSONResponseWithNonce(ctx, w, http.StatusCreated, account)
+}
+
+// RFC 8555 Section 7.3: an already-registered key gets a 200 with the
+// existing account URL in Location, rather than a 201.
+func (ca *CA) writeExistingAccount(ctx context.Context, w http.ResponseWriter, account *Account) {
+	ctx = WithAccountID(ctx, account.ID)
+	if account.Orders == "" {
+		account.Orders = ca.url(fmt.Sprintf("/account/%s/orders", account.ID))
+		if err := ca.storage.UpdateAccount(ctx, account); err != nil {
+			ca.logger.ErrorContext(ctx, "Failed to update account orders URL", "error", err)
+		}
+	}
+
+	w.Header().Set("Location", ca.url(fmt.Sprintf("/account/%s", account.ID)))
+	ca.writeJSONResponseWithNonce(ctx, w, http.StatusOK, account)
 }
 
 func (ca *CA) extractJWK(_ *http.Request, jws *jose.JSONWebSignature) (*jose.JSONWebKey, *Problem) {
@@ -219,7 +226,10 @@ func (ca *CA) lookupJWK(r *http.Request, jws *jose.JSONWebSignature) (*jose.JSON
 	account, err := ca.getAccount(ctx, accountID)
 	if err != nil {
 		ca.logger.DebugContext(ctx, "Account lookup failed", "account_id", accountID, "error", err)
-		return nil, AccountDoesNotExist("Account not found")
+		if errors.Is(err, ErrNotFound) {
+			return nil, AccountDoesNotExist("Account not found")
+		}
+		return nil, InternalServerError("Failed to look up account")
 	}
 
 	if account.Key == nil {
@@ -290,8 +300,8 @@ func (ca *CA) verifyPOST(r *http.Request, kx keyExtractor) (*authenticatedPOST, 
 
 	result, err := ca.verifyJWSWithKey(jws, pubKey, r)
 	if err != nil {
-		if isNonceError(err) {
-			return nil, BadNonce(err.Error())
+		if prob, ok := errors.AsType[*Problem](err); ok {
+			return nil, prob
 		}
 		return nil, Malformed(fmt.Sprintf("JWS verification failed: %v", err))
 	}
@@ -377,13 +387,31 @@ func (ca *CA) handleOrder(w http.ResponseWriter, r *http.Request) {
 
 	order, err := ca.storage.GetOrder(ctx, orderID)
 	if err != nil {
-		ca.writeProblem(ctx, w, Malformed("Order not found"))
+		ca.writeProblem(ctx, w, lookupProblem(err, "Order"))
 		return
 	}
 
 	if order.AccountID != postData.accountID {
 		ca.writeProblem(ctx, w, Unauthorized("Order does not belong to account"))
 		return
+	}
+
+	// A settled authorization whose pending-to-ready promotion failed has
+	// nothing left to retry it — re-POSTs of the valid challenge
+	// short-circuit and updateAuthorizationStatus returns early on final
+	// states — so recompute on poll; the guarded transition keeps this
+	// from overwriting a status another request has since written.
+	if order.Status == OrderStatusPending {
+		ca.updateOrderStatus(ctx, order)
+	}
+
+	// A crash mid-finalize leaves the order processing in storage, and an
+	// RFC 8555 Section 7.1.6 client polls processing without re-submitting
+	// finalize; once the reservation lapses the order must read as ready
+	// again so a retry can reclaim it. Presentation only — the durable
+	// reclaim happens when the retry reserves.
+	if order.Status == OrderStatusProcessing && !order.Reservation.Live(ca.reservationLease) {
+		order.Status = OrderStatusReady
 	}
 
 	if postData.postAsGet {
@@ -400,7 +428,8 @@ func (ca *CA) handleOrderFinalize(ctx context.Context, w http.ResponseWriter, or
 		return
 	}
 
-	if err := ca.finalizeCertificate(ctx, orderID, postData.accountID, finalizeReq.CSR); err != nil {
+	order, err := ca.finalizeCertificate(ctx, orderID, postData.accountID, finalizeReq.CSR)
+	if err != nil {
 		if prob, ok := errors.AsType[*Problem](err); ok {
 			ca.writeProblem(ctx, w, prob)
 		} else {
@@ -409,12 +438,6 @@ func (ca *CA) handleOrderFinalize(ctx context.Context, w http.ResponseWriter, or
 			ca.logger.ErrorContext(ctx, "Failed to finalize certificate", "error", err)
 			ca.writeProblem(ctx, w, InternalServerError("Failed to finalize certificate"))
 		}
-		return
-	}
-
-	order, err := ca.storage.GetOrder(ctx, orderID)
-	if err != nil {
-		ca.writeProblem(ctx, w, Malformed("Order not found"))
 		return
 	}
 
@@ -439,7 +462,7 @@ func (ca *CA) handleAuthorization(w http.ResponseWriter, r *http.Request) {
 
 	authz, err := ca.storage.GetAuthorization(ctx, authzID)
 	if err != nil {
-		ca.writeProblem(ctx, w, Malformed("Authorization not found"))
+		ca.writeProblem(ctx, w, lookupProblem(err, "Authorization"))
 		return
 	}
 	ctx = WithOrderID(ctx, authz.OrderID)
@@ -448,6 +471,12 @@ func (ca *CA) handleAuthorization(w http.ResponseWriter, r *http.Request) {
 		ca.writeProblem(ctx, w, Unauthorized("Authorization does not belong to account"))
 		return
 	}
+
+	// A settled challenge whose authorization promotion write was lost has
+	// nothing left to retry it — re-POSTs of a settled challenge
+	// short-circuit — so recompute on poll, as handleOrder does for
+	// pending orders.
+	ca.updateAuthorizationStatus(ctx, authz)
 
 	if postData.postAsGet {
 		ca.writeJSONResponseWithNonce(ctx, w, http.StatusOK, authz)
@@ -474,13 +503,13 @@ func (ca *CA) handleChallenge(w http.ResponseWriter, r *http.Request) {
 
 	challenge, err := ca.storage.GetChallenge(ctx, challengeID)
 	if err != nil {
-		ca.writeProblem(ctx, w, Malformed("Challenge not found"))
+		ca.writeProblem(ctx, w, lookupProblem(err, "Challenge"))
 		return
 	}
 
 	authz, err := ca.storage.GetAuthorization(ctx, challenge.AuthzID)
 	if err != nil {
-		ca.writeProblem(ctx, w, InternalServerError("Authorization not found for challenge"))
+		ca.writeProblem(ctx, w, InternalServerError("Failed to get authorization for challenge"))
 		return
 	}
 	ctx = WithOrderID(ctx, authz.OrderID)
@@ -490,11 +519,36 @@ func (ca *CA) handleChallenge(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// A crash mid-validation leaves the challenge processing in storage,
+	// and an RFC 8555 Section 7.1.6 client polls after responding once
+	// rather than re-POSTing; once the reservation lapses the challenge
+	// must read as pending again so the client can respond anew.
+	// Presentation only — the durable reclaim happens when the retry
+	// reserves.
+	if challenge.Status == ChallengeStatusProcessing && !challenge.Reservation.Live(ca.reservationLease) {
+		challenge.Status = ChallengeStatusPending
+	}
+
 	if postData.postAsGet {
 		ca.writeJSONResponseWithNonce(ctx, w, http.StatusOK, challenge)
-	} else {
-		ca.handleChallengeResponse(ctx, w, challenge, postData)
+		return
 	}
+
+	// RFC 8555 Section 7.1.6: valid and invalid are final, so a repeat POST
+	// reports the state instead of failing. A processing challenge falls
+	// through: the reserve answers duplicates with the current state while
+	// its lease is live, and lets a retry reclaim an interrupted validation
+	// once it lapses.
+	if challenge.Status == ChallengeStatusValid || challenge.Status == ChallengeStatusInvalid {
+		// The short-circuit skips the recompute a fresh validation would
+		// run, so a promotion lost to a transient write failure would
+		// otherwise never retry.
+		ca.updateAuthorizationStatus(ctx, authz)
+		ca.writeJSONResponseWithNonce(ctx, w, http.StatusOK, challenge)
+		return
+	}
+
+	ca.handleChallengeResponse(ctx, w, challenge, postData)
 }
 
 func (ca *CA) handleCertificate(w http.ResponseWriter, r *http.Request) {
@@ -515,7 +569,7 @@ func (ca *CA) handleCertificate(w http.ResponseWriter, r *http.Request) {
 
 	cert, err := ca.storage.GetCertificate(ctx, certID)
 	if err != nil {
-		ca.writeProblem(ctx, w, Malformed("Certificate not found"))
+		ca.writeProblem(ctx, w, lookupProblem(err, "Certificate"))
 		return
 	}
 
@@ -557,19 +611,25 @@ func (ca *CA) handleCertificate(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// scrubStorageState strips storage-internal state — the stored attestation
-// object — from a client-facing copy; the ACME wire format has no such
-// field.
+// scrubStorageState strips storage-internal state — the reservation and the
+// stored attestation object — from a client-facing copy; the ACME wire
+// format has neither field.
 func scrubStorageState(data any) any {
 	switch v := data.(type) {
+	case *Order:
+		scrubbed := *v
+		scrubbed.Reservation = nil
+		return &scrubbed
 	case *Challenge:
 		scrubbed := *v
+		scrubbed.Reservation = nil
 		scrubbed.Attestation = nil
 		return &scrubbed
 	case *Authorization:
 		scrubbed := *v
 		scrubbed.Challenges = slices.Clone(v.Challenges)
 		for i := range scrubbed.Challenges {
+			scrubbed.Challenges[i].Reservation = nil
 			scrubbed.Challenges[i].Attestation = nil
 		}
 		return &scrubbed
@@ -629,21 +689,23 @@ func (ca *CA) writeProblem(ctx context.Context, w http.ResponseWriter, prob *Pro
 	}
 }
 
+// validateNonce returns a *Problem so the badNonce/serverInternal distinction
+// is made once, where the storage error is known; verifyPOST unwraps it.
 func (ca *CA) validateNonce(ctx context.Context, nonce string) error {
-	if _, err := ca.storage.ConsumeNonce(ctx, nonce, ca.nonceExpiry); err != nil {
-		if errors.Is(err, ErrNonceNotFound) {
-			ca.logger.ErrorContext(ctx, "Nonce not found")
-			return &NonceValidationError{Err: ErrNonceNotFound}
-		}
-		if errors.Is(err, ErrNonceExpired) {
-			ca.logger.ErrorContext(ctx, "Nonce expired")
-			return &NonceValidationError{Err: ErrNonceExpired}
-		}
-
+	_, err := ca.storage.ConsumeNonce(ctx, nonce, ca.nonceExpiry)
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, ErrNotFound):
+		ca.logger.ErrorContext(ctx, "Nonce not found")
+		return BadNonce("Nonce not found")
+	case errors.Is(err, ErrNonceExpired):
+		ca.logger.ErrorContext(ctx, "Nonce expired")
+		return BadNonce("Nonce expired")
+	default:
 		ca.logger.ErrorContext(ctx, "Failed to consume nonce", "error", err)
-		return &NonceValidationError{Err: fmt.Errorf("failed to consume nonce: %w", err)}
+		return InternalServerError("Failed to validate nonce")
 	}
-	return nil
 }
 
 func (ca *CA) extractAccountIDFromKid(kid string) (string, error) {
@@ -669,8 +731,7 @@ func (ca *CA) generateAuthorizationID() string { return randomID(16) }
 func (ca *CA) generateChallengeID() string     { return randomID(16) }
 func (ca *CA) generateToken() string           { return randomID(32) }
 
-func (ca *CA) computeJWKHash(jwk *jose.JSONWebKey) (string, error) {
-	// Use JWK thumbprint as recommended by ACME spec
+func jwkThumbprint(jwk *jose.JSONWebKey) (string, error) {
 	thumbprint, err := jwk.Thumbprint(crypto.SHA256)
 	if err != nil {
 		return "", fmt.Errorf("failed to compute JWK thumbprint: %w", err)
@@ -679,11 +740,9 @@ func (ca *CA) computeJWKHash(jwk *jose.JSONWebKey) (string, error) {
 	return base64.RawURLEncoding.EncodeToString(thumbprint), nil
 }
 
+// createOrder assumes the account exists: its only caller reaches it through
+// lookupJWK, which has just loaded the account to authenticate the request.
 func (ca *CA) createOrder(ctx context.Context, accountID string, orderReq OrderRequest) (*Order, error) {
-	if _, err := ca.getAccount(ctx, accountID); err != nil {
-		return nil, fmt.Errorf("account not found: %w", err)
-	}
-
 	orderID := ca.generateOrderID()
 
 	var authzURLs []string
@@ -795,8 +854,18 @@ func (ca *CA) handleChallengeResponse(ctx context.Context, w http.ResponseWriter
 		AttStmt: attObj.AttStmt,
 	}
 
-	if err := ca.storage.SetChallengeProcessing(ctx, challenge.ID); err != nil {
-		ca.logger.ErrorContext(ctx, "Failed to update challenge status to processing", "error", err)
+	// The reservation is the persisted processing status under a lease:
+	// duplicate POSTs — concurrent, cross-process, or retries within the
+	// lease — are answered with the current state instead of a second
+	// validation, and a validation interrupted by a crash is reclaimed by
+	// a retry once the lease lapses.
+	reservationToken := randomID(16)
+	if err := ca.storage.ReserveChallengeValidation(ctx, challenge.ID, reservationToken, ca.reservationLease); err != nil {
+		if isFenceRejection(err) {
+			ca.reportChallengeState(ctx, w, challenge.ID)
+			return
+		}
+		ca.logger.ErrorContext(ctx, "Failed to reserve challenge for validation", "error", err)
 		ca.writeProblem(ctx, w, InternalServerError("Failed to update challenge status"))
 		return
 	}
@@ -804,36 +873,15 @@ func (ca *CA) handleChallengeResponse(ctx context.Context, w http.ResponseWriter
 	deviceInfo, err := verifier.Verify(ctx, stmt, []byte(challenge.Token))
 	if err != nil {
 		ca.logger.ErrorContext(ctx, "Attestation verification failed", "challenge_id", challenge.ID, "error", err)
-
-		now := time.Now()
-		prob := Unauthorized("Attestation verification failed")
-
-		if updateErr := ca.storage.SetChallengeInvalid(ctx, challenge.ID, now, prob); updateErr != nil {
-			ca.logger.ErrorContext(ctx, "Failed to update challenge status after verification failure", "error", updateErr)
-		}
-
-		ca.updateAuthorizationStatus(ctx, challenge.AuthzID)
-
-		ca.writeProblem(ctx, w, prob)
+		ca.failChallenge(ctx, w, challenge, reservationToken, Unauthorized("Attestation verification failed"))
 		return
 	}
-
-	// A validation that proves no identity must not settle valid: the
-	// DeviceInfo is what authorization and the certificate's SANs are
-	// built from.
+	// A validation that proves no identity must not settle valid: finalize
+	// derives the certificate's SANs from the DeviceInfo and refuses an
+	// order that yields none, so accepting it here would wedge the order.
 	if deviceInfo == nil {
 		ca.logger.ErrorContext(ctx, "Attestation verifier returned no device identity", "challenge_id", challenge.ID, "format", attObj.Format)
-
-		now := time.Now()
-		prob := Unauthorized("Attestation yielded no device identity")
-
-		if updateErr := ca.storage.SetChallengeInvalid(ctx, challenge.ID, now, prob); updateErr != nil {
-			ca.logger.ErrorContext(ctx, "Failed to update challenge status after empty verification", "error", updateErr)
-		}
-
-		ca.updateAuthorizationStatus(ctx, challenge.AuthzID)
-
-		ca.writeProblem(ctx, w, prob)
+		ca.failChallenge(ctx, w, challenge, reservationToken, Unauthorized("Attestation yielded no device identity"))
 		return
 	}
 
@@ -841,14 +889,17 @@ func (ca *CA) handleChallengeResponse(ctx context.Context, w http.ResponseWriter
 	if err != nil {
 		ca.logger.ErrorContext(ctx, "Device authorization check failed", "challenge_id", challenge.ID, "error", err)
 
-		now := time.Now()
-		prob := InternalServerError("Authorization check failed")
-
-		if updateErr := ca.storage.SetChallengeInvalid(ctx, challenge.ID, now, prob); updateErr != nil {
-			ca.logger.ErrorContext(ctx, "Failed to update challenge status after authorization error", "error", updateErr)
+		// A failed authorizer call is a backend condition, not a verdict on
+		// the attestation; surrender the reservation so a retry can
+		// validate once it clears, instead of invalidating the challenge.
+		if releaseErr := ca.storage.ReleaseChallengeValidation(ctx, challenge.ID, reservationToken); releaseErr != nil {
+			// A fencing rejection means another request settled the
+			// challenge; its result stands. Anything else leaves the
+			// challenge processing, and it heals by lease expiry.
+			if !isFenceRejection(releaseErr) {
+				ca.logger.ErrorContext(ctx, "Failed to release challenge after authorization error", "error", releaseErr)
+			}
 		}
-
-		ca.updateAuthorizationStatus(ctx, challenge.AuthzID)
 
 		ca.writeProblem(ctx, w, InternalServerError("Device authorization check failed"))
 		return
@@ -856,22 +907,17 @@ func (ca *CA) handleChallengeResponse(ctx context.Context, w http.ResponseWriter
 
 	if !authorized {
 		ca.logger.WarnContext(ctx, "Device not authorized", "challenge_id", challenge.ID)
-
-		now := time.Now()
-		prob := Unauthorized("Device not authorized for certificate issuance")
-
-		if updateErr := ca.storage.SetChallengeInvalid(ctx, challenge.ID, now, prob); updateErr != nil {
-			ca.logger.ErrorContext(ctx, "Failed to update challenge status after authorization denial", "error", updateErr)
-		}
-
-		ca.updateAuthorizationStatus(ctx, challenge.AuthzID)
-
-		ca.writeProblem(ctx, w, prob)
+		ca.failChallenge(ctx, w, challenge, reservationToken, Unauthorized("Device not authorized for certificate issuance"))
 		return
 	}
 
 	now := time.Now()
-	if err := ca.storage.SetChallengeValid(ctx, challenge.ID, now, attObj.AttStmt); err != nil {
+	if err := ca.storage.SetChallengeValid(ctx, challenge.ID, reservationToken, now, attObjBytes); err != nil {
+		// Another writer settled the challenge first; report its result.
+		if isFenceRejection(err) {
+			ca.reportChallengeState(ctx, w, challenge.ID)
+			return
+		}
 		ca.logger.ErrorContext(ctx, "Failed to update challenge status to valid", "error", err)
 		ca.writeProblem(ctx, w, InternalServerError("Failed to update challenge status"))
 		return
@@ -879,7 +925,9 @@ func (ca *CA) handleChallengeResponse(ctx context.Context, w http.ResponseWriter
 
 	ca.logger.InfoContext(ctx, "Challenge validated", "challenge_id", challenge.ID, "type", challenge.Type)
 
-	ca.updateAuthorizationStatus(ctx, challenge.AuthzID)
+	if authz, err := ca.storage.GetAuthorization(ctx, challenge.AuthzID); err == nil {
+		ca.updateAuthorizationStatus(ctx, authz)
+	}
 
 	challenge, err = ca.storage.GetChallenge(ctx, challenge.ID)
 	if err != nil {
@@ -890,9 +938,43 @@ func (ca *CA) handleChallengeResponse(ctx context.Context, w http.ResponseWriter
 	ca.writeJSONResponseWithNonce(ctx, w, http.StatusOK, challenge)
 }
 
+// reportChallengeState answers a request that lost a validation race with
+// the challenge's current stored state.
+func (ca *CA) reportChallengeState(ctx context.Context, w http.ResponseWriter, challengeID string) {
+	current, err := ca.storage.GetChallenge(ctx, challengeID)
+	if err != nil {
+		ca.logger.ErrorContext(ctx, "Failed to get challenge after lost validation race", "error", err)
+		ca.writeProblem(ctx, w, InternalServerError("Failed to get challenge"))
+		return
+	}
+	ca.writeJSONResponseWithNonce(ctx, w, http.StatusOK, current)
+}
+
+// failChallenge settles a reserved challenge as invalid and reports prob. A
+// fencing rejection means another request settled the challenge first: its
+// result is reported instead and the recompute is left to it.
+func (ca *CA) failChallenge(ctx context.Context, w http.ResponseWriter, challenge *Challenge, reservationToken string, prob *Problem) {
+	if err := ca.storage.SetChallengeInvalid(ctx, challenge.ID, reservationToken, time.Now(), prob); err != nil {
+		if isFenceRejection(err) {
+			ca.reportChallengeState(ctx, w, challenge.ID)
+			return
+		}
+		ca.logger.ErrorContext(ctx, "Failed to update challenge status", "error", err)
+	}
+
+	if authz, err := ca.storage.GetAuthorization(ctx, challenge.AuthzID); err == nil {
+		ca.updateAuthorizationStatus(ctx, authz)
+	}
+	ca.writeProblem(ctx, w, prob)
+}
+
+// updateOrderStatus promotes a pending order once its authorizations settle.
+// The pending-only guard — enforced again by SetOrderStatus against the
+// stored record — keeps this recomputation from overwriting a status a
+// concurrent finalize has since written.
 func (ca *CA) updateOrderStatus(ctx context.Context, order *Order) {
-	if order.Status == OrderStatusValid || order.Status == OrderStatusInvalid {
-		return // Final states
+	if order.Status != OrderStatusPending {
+		return
 	}
 
 	allValid := true
@@ -915,30 +997,38 @@ func (ca *CA) updateOrderStatus(ctx context.Context, order *Order) {
 		}
 	}
 
-	oldStatus := order.Status
-	if anyInvalid {
-		order.Status = OrderStatusInvalid
-	} else if allValid {
-		order.Status = OrderStatusReady
-	}
-
-	if oldStatus != order.Status {
-		ca.logger.DebugContext(ctx, "Order status changed", "order_id", order.ID, "old_status", oldStatus, "new_status", order.Status)
-	}
-
-	if err := ca.storage.UpdateOrder(ctx, order); err != nil {
-		ca.logger.ErrorContext(ctx, "Failed to update order status", "error", err)
-	}
-}
-
-func (ca *CA) updateAuthorizationStatus(ctx context.Context, authzID string) {
-	authz, err := ca.storage.GetAuthorization(ctx, authzID)
-	if err != nil {
+	var next string
+	switch {
+	case anyInvalid:
+		next = OrderStatusInvalid
+	case allValid:
+		next = OrderStatusReady
+	default:
 		return
 	}
 
-	if authz.Status == AuthzStatusValid || authz.Status == AuthzStatusInvalid {
-		return // Final states
+	// A mismatch means another request settled the order first; its result
+	// stands.
+	if err := ca.storage.SetOrderStatus(ctx, order.ID, OrderStatusPending, next); err != nil {
+		if !errors.Is(err, ErrStatusMismatch) {
+			ca.logger.ErrorContext(ctx, "Failed to update order status", "error", err)
+		}
+		return
+	}
+
+	ca.logger.DebugContext(ctx, "Order status changed", "order_id", order.ID, "old_status", order.Status, "new_status", next)
+	order.Status = next
+}
+
+// updateAuthorizationStatus settles a pending authorization once its
+// challenges settle, refreshing the embedded challenge copies with the
+// transition. The pending-only guard — enforced again by
+// SettleAuthorization against the stored record — keeps a recompute from
+// stale reads from overwriting a settlement another request has since
+// written; a recompute that settles nothing writes nothing.
+func (ca *CA) updateAuthorizationStatus(ctx context.Context, authz *Authorization) {
+	if authz.Status != AuthzStatusPending {
+		return
 	}
 
 	// An authorization with no challenges must not count as valid.
@@ -952,9 +1042,17 @@ func (ca *CA) updateAuthorizationStatus(ctx context.Context, authzID string) {
 			continue
 		}
 
-		// The attestation blob belongs to the challenge record: finalize
-		// re-reads it there, so an embedded copy is dead weight persisted
-		// with every settled authorization.
+		// A processing challenge whose reservation lapsed reads as pending
+		// here for the same reason handleChallenge presents it that way: an
+		// RFC 8555 Section 7.5.1 client polls the authorization object, and
+		// a challenge shown as processing forever would never be re-POSTed.
+		if currentChallenge.Status == ChallengeStatusProcessing && !currentChallenge.Reservation.Live(ca.reservationLease) {
+			currentChallenge.Status = ChallengeStatusPending
+		}
+
+		// Reservations and attestation blobs belong to the challenge
+		// record, not embedded copies.
+		currentChallenge.Reservation = nil
 		currentChallenge.Attestation = nil
 		authz.Challenges[i] = *currentChallenge
 
@@ -967,95 +1065,87 @@ func (ca *CA) updateAuthorizationStatus(ctx context.Context, authzID string) {
 		}
 	}
 
-	oldStatus := authz.Status
-	if anyInvalid {
-		authz.Status = AuthzStatusInvalid
-	} else if allValid {
-		authz.Status = AuthzStatusValid
+	var next string
+	switch {
+	case anyInvalid:
+		next = AuthzStatusInvalid
+	case allValid:
+		next = AuthzStatusValid
+	default:
+		return
 	}
 
-	if oldStatus != authz.Status {
-		ca.logger.DebugContext(ctx, "Authorization status changed", "authz_id", authzID, "old_status", oldStatus, "new_status", authz.Status)
+	// A mismatch means another request settled the authorization first;
+	// its result stands.
+	authz.Status = next
+	if err := ca.storage.SettleAuthorization(ctx, authz); err != nil {
+		authz.Status = AuthzStatusPending
+		if !errors.Is(err, ErrStatusMismatch) {
+			ca.logger.ErrorContext(ctx, "Failed to update authorization status", "error", err)
+		}
+		return
 	}
 
-	if err := ca.storage.UpdateAuthorization(ctx, authz); err != nil {
-		ca.logger.ErrorContext(ctx, "Failed to update authorization status", "error", err)
-	}
+	ca.logger.DebugContext(ctx, "Authorization status changed", "authz_id", authz.ID, "old_status", AuthzStatusPending, "new_status", next)
 
-	if oldStatus != authz.Status && authz.OrderID != "" {
+	if authz.OrderID != "" {
 		if order, err := ca.storage.GetOrder(ctx, authz.OrderID); err == nil {
 			ca.updateOrderStatus(ctx, order)
 		}
 	}
 }
 
-func (ca *CA) finalizeCertificate(ctx context.Context, orderID, accountID string, csrB64 string) error {
+func (ca *CA) finalizeCertificate(ctx context.Context, orderID, accountID string, csrB64 string) (*Order, error) {
 	// Decode base64url-encoded CSR DER
 	// RFC 8555 Section 7.4: "csr (required, string): A CSR encoding the parameters for the
 	// certificate being requested [RFC2986]. The CSR is sent in the
 	// base64url-encoded version of the DER format."
 	csrDER, err := base64.RawURLEncoding.DecodeString(csrB64)
 	if err != nil {
-		return BadCSR("Invalid CSR base64url encoding")
+		return nil, BadCSR("Invalid CSR base64url encoding")
 	}
 
 	csr, err := x509.ParseCertificateRequest(csrDER)
 	if err != nil {
-		return BadCSR("Failed to parse CSR")
+		return nil, BadCSR("Failed to parse CSR")
 	}
 
 	if err := csr.CheckSignature(); err != nil {
-		return BadCSR(fmt.Sprintf("CSR signature verification failed: %s", err.Error()))
+		return nil, BadCSR(fmt.Sprintf("CSR signature verification failed: %s", err.Error()))
 	}
 
+	// Existence and ownership are settled before the reservation is taken,
+	// so a request that has no claim on the order can never hold its lock.
 	order, err := ca.storage.GetOrder(ctx, orderID)
 	if err != nil {
-		return Malformed("Order not found")
+		return nil, lookupProblem(err, "Order")
 	}
 
 	if order.AccountID != accountID {
-		return Unauthorized("Order does not belong to account")
+		return nil, Unauthorized("Order does not belong to account")
 	}
 
-	if order.Status != OrderStatusReady {
-		return OrderNotReady("Order is not ready for finalization")
-	}
-
-	var deviceInfos []*DeviceInfo
-	for _, authzURL := range order.Authorizations {
-		authzID := extractIDFromURL(authzURL, "/authz/")
-		authz, err := ca.storage.GetAuthorization(ctx, authzID)
-		if err != nil || authz.Status != AuthzStatusValid {
-			continue
+	// The reservation is the persisted processing status under a lease, so
+	// exclusivity holds across CA processes sharing this storage, and a
+	// crashed holder is reclaimable once the lease lapses. The snapshot
+	// read above stays valid: readiness is judged atomically by the
+	// reserve, and every field used below is immutable after CreateOrder.
+	token := randomID(16)
+	if err := ca.storage.ReserveOrderFinalize(ctx, orderID, token, ca.reservationLease); err != nil {
+		switch {
+		case errors.Is(err, ErrReserved):
+			return nil, OrderNotReady("Order finalization is already in progress")
+		case errors.Is(err, ErrStatusMismatch):
+			return nil, OrderNotReady("Order is not ready for finalization")
+		case errors.Is(err, ErrNotFound):
+			return nil, lookupProblem(err, "Order")
 		}
-
-		for _, challenge := range authz.Challenges {
-			if challenge.Status == ChallengeStatusValid {
-				challengeObj, err := ca.storage.GetChallenge(ctx, challenge.ID)
-				if err == nil && challengeObj != nil {
-					deviceInfo, err := ca.extractDeviceInfoFromChallenge(ctx, challengeObj)
-					if err == nil && deviceInfo != nil {
-						deviceInfos = append(deviceInfos, deviceInfo)
-					}
-				}
-				break
-			}
-		}
+		return nil, fmt.Errorf("failed to reserve order for finalization: %w", err)
 	}
 
-	cert, err := ca.certificateIssuer.IssueCertificate(ctx, csr, deviceInfos)
+	cert, deviceInfos, err := ca.issueForOrder(ctx, order, csr, token)
 	if err != nil {
-		return fmt.Errorf("failed to issue certificate: %w", err)
-	}
-
-	if err := ca.storage.CreateCertificate(ctx, cert); err != nil {
-		return fmt.Errorf("failed to store certificate: %w", err)
-	}
-
-	order.Status = OrderStatusValid
-	order.Certificate = ca.url(fmt.Sprintf("/certificate/%s", cert.SerialNumber))
-	if err := ca.storage.UpdateOrder(ctx, order); err != nil {
-		return fmt.Errorf("failed to update order: %w", err)
+		return nil, err
 	}
 
 	ca.logger.InfoContext(ctx, "Certificate issued", "serial_number", cert.SerialNumber)
@@ -1096,32 +1186,142 @@ func (ca *CA) finalizeCertificate(ctx context.Context, orderID, accountID string
 		}
 	}
 
-	return nil
+	return order, nil
 }
 
+// issueForOrder issues the certificate for a reserved order and commits it
+// atomically with the order's valid transition. Nothing is persisted until
+// that commit, so a failure releases the reservation and discards the
+// signed certificate — a retry issues a fresh certificate for the CSR it
+// actually carries, so a stored certificate never predates the CSR that
+// finalized the order — and a crash leaves the order processing until the
+// lease lapses and a retry reclaims it.
+func (ca *CA) issueForOrder(ctx context.Context, order *Order, csr *x509.CertificateRequest, token string) (*Certificate, []*DeviceInfo, error) {
+	deviceInfos, err := ca.deviceInfosForOrder(ctx, order)
+	if err != nil {
+		return nil, nil, ca.failOrder(ctx, order.ID, token, err)
+	}
+
+	cert, err := ca.certificateIssuer.IssueCertificate(ctx, csr, deviceInfos)
+	if err != nil {
+		return nil, nil, ca.failOrder(ctx, order.ID, token, fmt.Errorf("failed to issue certificate: %w", err))
+	}
+	cert.ID = order.ID
+
+	order.Status = OrderStatusValid
+	order.Certificate = ca.url(fmt.Sprintf("/certificate/%s", cert.ID))
+	order.Reservation = nil
+	if err := ca.storage.CompleteOrder(ctx, order, cert, token); err != nil {
+		ca.logger.ErrorContext(ctx, "Discarding signed certificate after failed completion", "serial_number", cert.SerialNumber, "error", err)
+		// A fencing rejection means the lease lapsed and another finalize
+		// reclaimed the order; its outcome stands and there is no
+		// reservation left to release. That is a client-state condition
+		// like losing the reserve itself, not a backend failure: a 5xx
+		// would invite a retry of a finalize that has been superseded.
+		if isFenceRejection(err) {
+			return nil, nil, OrderNotReady("Order finalization was superseded by another request")
+		}
+		return nil, nil, ca.failOrder(ctx, order.ID, token, fmt.Errorf("failed to complete order: %w", err))
+	}
+
+	return cert, deviceInfos, nil
+}
+
+// failOrder releases the finalize reservation, distinguishing terminal
+// failures from transient ones. A client-fault problem can only recur on
+// retry, so the order moves to invalid per RFC 8555 Section 7.1.6 and the
+// client abandons it; anything else returns the order to ready so a retry
+// can finalize again.
+func (ca *CA) failOrder(ctx context.Context, orderID, token string, err error) error {
+	to := OrderStatusReady
+	if prob, ok := errors.AsType[*Problem](err); ok && prob.Status < http.StatusInternalServerError {
+		to = OrderStatusInvalid
+	}
+	switch serr := ca.storage.ReleaseOrderFinalize(ctx, orderID, token, to); {
+	case serr == nil:
+	case isFenceRejection(serr):
+		// The lease lapsed and another finalize took over; its outcome
+		// stands.
+		ca.logger.DebugContext(ctx, "Finalize reservation was reclaimed", "error", serr)
+	default:
+		// The order stays processing and heals by lease expiry.
+		ca.logger.ErrorContext(ctx, "Failed to release order after finalize failure", "error", serr)
+	}
+	return err
+}
+
+// deviceInfosForOrder re-derives the attested device identity for each valid
+// authorization. Any failure aborts the finalize: the order only reached
+// "ready" through a successful attestation, so issuing without the identity
+// it proved would silently strip the SANs from the certificate. An empty
+// result means no authorization reads valid — inconsistent state that may
+// heal — so it is refused as retriable rather than issued identity-less.
+func (ca *CA) deviceInfosForOrder(ctx context.Context, order *Order) ([]*DeviceInfo, error) {
+	var deviceInfos []*DeviceInfo
+	for _, authzURL := range order.Authorizations {
+		authzID := extractIDFromURL(authzURL, "/authz/")
+		authz, err := ca.storage.GetAuthorization(ctx, authzID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get authorization: %w", err)
+		}
+		if authz.Status != AuthzStatusValid {
+			continue
+		}
+
+		for _, challenge := range authz.Challenges {
+			if challenge.Status != ChallengeStatusValid {
+				continue
+			}
+			challengeObj, err := ca.storage.GetChallenge(ctx, challenge.ID)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get challenge: %w", err)
+			}
+			deviceInfo, err := ca.extractDeviceInfoFromChallenge(ctx, challengeObj)
+			if err != nil {
+				return nil, fmt.Errorf("failed to extract device info: %w", err)
+			}
+			if deviceInfo != nil {
+				deviceInfos = append(deviceInfos, deviceInfo)
+			}
+			break
+		}
+	}
+	if len(deviceInfos) == 0 {
+		return nil, errors.New("no valid authorization yields an attested identity")
+	}
+	return deviceInfos, nil
+}
+
+// extractDeviceInfoFromChallenge re-verifies the attestation stored with a
+// validated challenge. A missing or undecodable stored attestation can only
+// recur on retry, so those are unauthorized problems failOrder treats as
+// terminal. A missing verifier is this instance's configuration and a
+// re-verification failure is environmental — the statement already passed
+// verification at challenge time — so both return plain errors that keep
+// the order retriable.
 func (ca *CA) extractDeviceInfoFromChallenge(ctx context.Context, challenge *Challenge) (*DeviceInfo, error) {
-	if challenge.Attestation == nil {
-		return nil, errors.New("no attestation data in challenge")
+	if len(challenge.Attestation) == 0 {
+		return nil, Unauthorized("No attestation recorded for challenge")
 	}
 
-	format, ok := challenge.Attestation["fmt"].(string)
-	if !ok {
-		return nil, errors.New("attestation format not found")
+	var attObj AttestationObject
+	if err := cbor.Unmarshal(challenge.Attestation, &attObj); err != nil {
+		return nil, Unauthorized("Stored attestation is not usable")
 	}
 
-	verifier, exists := ca.verifiers[format]
+	verifier, exists := ca.verifiers[attObj.Format]
 	if !exists {
-		return nil, fmt.Errorf("no verifier for format: %s", format)
+		return nil, fmt.Errorf("no verifier registered for attestation format %q", attObj.Format)
 	}
 
 	stmt := AttestationStatement{
-		Format:  format,
-		AttStmt: challenge.Attestation,
+		Format:  attObj.Format,
+		AttStmt: attObj.AttStmt,
 	}
 
 	deviceInfo, err := verifier.Verify(ctx, stmt, []byte(challenge.Token))
 	if err != nil {
-		return nil, fmt.Errorf("failed to verify attestation: %w", err)
+		return nil, fmt.Errorf("failed to re-verify attestation: %w", err)
 	}
 
 	return deviceInfo, nil

--- a/handlers_finalize_test.go
+++ b/handlers_finalize_test.go
@@ -1,6 +1,7 @@
 package nanoca_test
 
 import (
+	"bytes"
 	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
@@ -8,8 +9,11 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"errors"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync"
 	"testing"
 
 	"github.com/brandonweeks/nanoca"
@@ -55,7 +59,7 @@ func driveToReady(t *testing.T, ts *httptest.Server) (*acme.Client, *acme.Order)
 func TestFinalizeIssuerError(t *testing.T) {
 	t.Parallel()
 
-	ts, _ := newTestServer(t, nullauthorizer.New(), failingIssuer{}, nil)
+	ts, _ := newTestServer(t, testServerConfig{issuer: failingIssuer{}})
 
 	client, order := driveToReady(t, ts)
 	if _, _, err := client.CreateOrderCert(t.Context(), order.FinalizeURL, newCSR(t), true); err == nil {
@@ -63,10 +67,45 @@ func TestFinalizeIssuerError(t *testing.T) {
 	}
 }
 
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// The client only sees "Failed to finalize certificate", so the causing error
+// has to reach the server log or the 500 cannot be debugged.
+func TestFinalizeIssuerErrorLogged(t *testing.T) {
+	t.Parallel()
+
+	var logs syncBuffer
+	ts, _ := newTestServer(t, testServerConfig{logger: slog.New(slog.NewTextHandler(&logs, nil)), issuer: failingIssuer{}})
+
+	client, order := driveToReady(t, ts)
+	if _, _, err := client.CreateOrderCert(t.Context(), order.FinalizeURL, newCSR(t), true); err == nil {
+		t.Fatal("CreateOrderCert() error = nil, want issuer failure")
+	}
+
+	if !strings.Contains(logs.String(), "issuer unavailable") {
+		t.Errorf("finalize failure logs omit the issuer error %q:\n%s", "issuer unavailable", logs.String())
+	}
+}
+
 func TestFinalizeObserverErrorStillIssues(t *testing.T) {
 	t.Parallel()
 
-	ts, _ := newTestServer(t, nullauthorizer.New(), nil, failingObserver{})
+	ts, _ := newTestServer(t, testServerConfig{observer: failingObserver{}})
 
 	client, order := driveToReady(t, ts)
 	cert, _, err := client.CreateOrderCert(t.Context(), order.FinalizeURL, newCSR(t), true)

--- a/handlers_flow_test.go
+++ b/handlers_flow_test.go
@@ -27,11 +27,20 @@ func (d denyAuthorizer) Authorize(context.Context, *nanoca.DeviceInfo) (bool, er
 
 func newACMEClient(t *testing.T, ts *httptest.Server) *acme.Client {
 	t.Helper()
+	client := newUnregisteredClient(t, ts)
+	if _, err := client.Register(t.Context(), &acme.Account{}, acme.AcceptTOS); err != nil {
+		t.Fatalf("failed to register account: %v", err)
+	}
+	return client
+}
+
+func newUnregisteredClient(t *testing.T, ts *httptest.Server) *acme.Client {
+	t.Helper()
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		t.Fatalf("failed to generate key: %v", err)
 	}
-	client := &acme.Client{
+	return &acme.Client{
 		DirectoryURL: ts.URL + "/directory",
 		HTTPClient:   ts.Client(),
 		Key:          key,
@@ -39,10 +48,6 @@ func newACMEClient(t *testing.T, ts *httptest.Server) *acme.Client {
 		// test context is cancelled; fail on the first response instead.
 		RetryBackoff: func(int, *http.Request, *http.Response) time.Duration { return -1 },
 	}
-	if _, err := client.Register(t.Context(), &acme.Account{}, acme.AcceptTOS); err != nil {
-		t.Fatalf("failed to register account: %v", err)
-	}
-	return client
 }
 
 func pendingChallenge(t *testing.T, client *acme.Client, value string) (*acme.Order, *acme.Challenge) {
@@ -130,6 +135,27 @@ func TestMalformedAttestations(t *testing.T) {
 				t.Error("Accept() error = nil, want error")
 			}
 		})
+	}
+}
+
+// Re-POSTing an already-validated challenge is a client-state condition, not
+// a backend failure: a 5xx tells the client to retry an operation that can
+// never succeed (see the RetryBackoff comment above).
+func TestChallengeDuplicateSubmission(t *testing.T) {
+	t.Parallel()
+
+	ts, _ := setupTestServerWithAttestation(t, nullauthorizer.New())
+	client := newACMEClient(t, ts)
+
+	_, chal := pendingChallenge(t, client, "duplicate-device")
+	if err := submitAttObj(t, client, chal, nullAttObj(t)); err != nil {
+		t.Fatalf("failed to satisfy challenge: %v", err)
+	}
+
+	err := submitAttObj(t, client, chal, nullAttObj(t))
+	var ae *acme.Error
+	if errors.As(err, &ae) && ae.StatusCode >= http.StatusInternalServerError {
+		t.Errorf("duplicate challenge POST status = %d, want non-5xx", ae.StatusCode)
 	}
 }
 
@@ -236,8 +262,9 @@ func TestOrderBelongsToAnotherAccount(t *testing.T) {
 
 // createOrder builds challenges only for permanent-identifier and
 // hardware-module identifiers, so any other type yields an authorization
-// with zero challenges — an authorization that must never settle valid and
-// an order that must never be promoted, since nothing was ever validated.
+// with zero challenges. Over an empty challenge list every recompute reads
+// all-valid, so such an authorization must never settle valid — nothing was
+// ever validated — and its order must not be promoted toward issuance.
 func TestZeroChallengeAuthorizationNotSettledValid(t *testing.T) {
 	t.Parallel()
 

--- a/handlers_internal_test.go
+++ b/handlers_internal_test.go
@@ -6,32 +6,43 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
-// The stored attestation object is a storage concern; it must never reach
-// the ACME wire format, and scrubbing it must not mutate the stored
-// record's copy.
+// Reservations and the stored attestation blob are storage concerns; they
+// must never reach the ACME wire format, and scrubbing them must not mutate
+// the stored record's copy.
 func TestWriteJSONResponseScrubsStorageState(t *testing.T) {
 	t.Parallel()
 
 	ca := &CA{logger: slog.New(slog.DiscardHandler)}
-	attestation := map[string]any{"fmt": "apple", "x5c": "leaf"}
+	reservation := func() *Reservation {
+		return &Reservation{Token: "token", ReservedAt: time.Now()}
+	}
+	attestation := []byte("attestation-object")
 
-	challenge := &Challenge{ID: "c1", Status: ChallengeStatusValid, Attestation: attestation}
-	authz := &Authorization{ID: "a1", Challenges: []Challenge{{ID: "c1", Attestation: attestation}}}
+	order := &Order{ID: "o1", Status: OrderStatusProcessing, Reservation: reservation()}
+	challenge := &Challenge{ID: "c1", Status: ChallengeStatusValid, Attestation: attestation, Reservation: reservation()}
+	authz := &Authorization{ID: "a1", Challenges: []Challenge{{ID: "c1", Attestation: attestation, Reservation: reservation()}}}
 
 	for name, data := range map[string]any{
+		"order":         order,
 		"challenge":     challenge,
 		"authorization": authz,
 	} {
 		rec := httptest.NewRecorder()
 		ca.writeJSONResponse(t.Context(), rec, http.StatusOK, data, "")
-		if body := rec.Body.String(); strings.Contains(body, "attestation") {
-			t.Errorf("%s response leaks attestation state:\n%s", name, body)
+		for _, field := range []string{"reservation", "attestation"} {
+			if body := rec.Body.String(); strings.Contains(body, field) {
+				t.Errorf("%s response leaks %s state:\n%s", name, field, body)
+			}
 		}
 	}
 
-	if challenge.Attestation == nil || authz.Challenges[0].Attestation == nil {
+	if order.Reservation == nil || challenge.Reservation == nil || authz.Challenges[0].Reservation == nil {
 		t.Error("scrubbing mutated the caller's records")
+	}
+	if challenge.Attestation == nil || authz.Challenges[0].Attestation == nil {
+		t.Error("scrubbing mutated the caller's attestation")
 	}
 }

--- a/handlers_recovery_test.go
+++ b/handlers_recovery_test.go
@@ -1,0 +1,547 @@
+package nanoca_test
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/brandonweeks/nanoca"
+	"github.com/fxamacker/cbor/v2"
+	"golang.org/x/crypto/acme"
+)
+
+func attObjFor(t *testing.T, format string) string {
+	t.Helper()
+	b, err := cbor.Marshal(map[string]any{"fmt": format, "attStmt": map[string]any{}})
+	if err != nil {
+		t.Fatalf("failed to marshal attestation: %v", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(b)
+}
+
+// gateVerifier scripts two validations of one challenge: the first (a
+// zombie whose lease will lapse) blocks until released and fails, the
+// second (the reclaiming retry) blocks until released and succeeds.
+type gateVerifier struct {
+	mu      sync.Mutex
+	calls   int
+	entered [2]chan struct{}
+	release [2]chan struct{}
+}
+
+func newGateVerifier() *gateVerifier {
+	return &gateVerifier{
+		entered: [2]chan struct{}{make(chan struct{}), make(chan struct{})},
+		release: [2]chan struct{}{make(chan struct{}), make(chan struct{})},
+	}
+}
+
+func (v *gateVerifier) Format() string { return "gate" }
+
+func (v *gateVerifier) Verify(context.Context, nanoca.AttestationStatement, []byte) (*nanoca.DeviceInfo, error) {
+	v.mu.Lock()
+	call := v.calls
+	v.calls++
+	v.mu.Unlock()
+	if call < 2 {
+		close(v.entered[call])
+		<-v.release[call]
+	}
+	if call == 0 {
+		return nil, errors.New("verifier unavailable")
+	}
+	return &nanoca.DeviceInfo{
+		PermanentIdentifier: &nanoca.PermanentIdentifier{Identifier: "gate-device"},
+	}, nil
+}
+
+// authzWriteParkingStorage parks armed SettleAuthorization calls until the
+// test releases them, so a stale authorization write can be made to land
+// after a newer one.
+type authzWriteParkingStorage struct {
+	nanoca.Storage
+	mu     sync.Mutex
+	toPark int
+	parked chan chan struct{}
+}
+
+func (s *authzWriteParkingStorage) park(n int) {
+	s.mu.Lock()
+	s.toPark = n
+	s.mu.Unlock()
+}
+
+func (s *authzWriteParkingStorage) SettleAuthorization(ctx context.Context, authz *nanoca.Authorization) error {
+	s.mu.Lock()
+	if s.toPark > 0 {
+		s.toPark--
+		s.mu.Unlock()
+		gate := make(chan struct{})
+		s.parked <- gate
+		<-gate
+	} else {
+		s.mu.Unlock()
+	}
+	return s.Storage.SettleAuthorization(ctx, authz)
+}
+
+// A zombie validation whose fenced SetChallengeInvalid is rejected has no
+// claim left on the challenge, yet it still recomputes the authorization.
+// Its stale write must not revert an authorization a reclaiming retry has
+// settled valid: with the order already ready, a reverted authorization is
+// skipped by finalize's device-info collection and the certificate is
+// issued without the attested identifiers.
+func TestZombieInvalidationDoesNotRevertSettledAuthz(t *testing.T) {
+	t.Parallel()
+
+	verifier := newGateVerifier()
+	storage := &authzWriteParkingStorage{Storage: newTestStorage(t), parked: make(chan chan struct{}, 1)}
+	ts, _ := newTestServer(t, testServerConfig{
+		storage:   storage,
+		opts:      []nanoca.Option{nanoca.WithReservationLease(testReservationLease)},
+		verifiers: []nanoca.AttestationVerifier{verifier},
+	})
+
+	client := newACMEClient(t, ts)
+	order, chal := pendingChallenge(t, client, "zombie-authz-device")
+
+	payload, err := json.Marshal(map[string]any{"attObj": attObjFor(t, "gate")})
+	if err != nil {
+		t.Fatalf("failed to marshal payload: %v", err)
+	}
+	chal.Payload = payload
+
+	zombieDone := make(chan error, 1)
+	go func() {
+		_, err := client.Accept(t.Context(), chal)
+		zombieDone <- err
+	}()
+	<-verifier.entered[0]
+
+	// The zombie holds the reservation inside its verifier; once the lease
+	// lapses, the retry reclaims it and parks inside its own verifier.
+	time.Sleep(2 * testReservationLease)
+	retryDone := make(chan error, 1)
+	go func() {
+		_, err := client.Accept(t.Context(), chal)
+		retryDone <- err
+	}()
+	<-verifier.entered[1]
+
+	// The zombie fails verification while the retry holds the reservation,
+	// so its fenced SetChallengeInvalid is rejected. If it goes on to
+	// recompute the authorization anyway, its stale write parks; if it
+	// stops at the fencing rejection, it finishes without writing.
+	storage.park(1)
+	close(verifier.release[0])
+	var gate chan struct{}
+	select {
+	case gate = <-storage.parked:
+	case <-zombieDone:
+		storage.park(0)
+	}
+
+	close(verifier.release[1])
+	if err := <-retryDone; err != nil {
+		t.Fatalf("reclaiming Accept() error = %v, want success", err)
+	}
+
+	// The retry has settled: challenge valid, authorization valid, order
+	// ready. Any parked zombie write lands last.
+	if gate != nil {
+		close(gate)
+		<-zombieDone
+	}
+
+	authz, err := client.GetAuthorization(t.Context(), order.AuthzURLs[0])
+	if err != nil {
+		t.Fatalf("GetAuthorization() error = %v", err)
+	}
+	if authz.Status != acme.StatusValid {
+		t.Errorf("authorization status after zombie write = %q, want %q", authz.Status, acme.StatusValid)
+	}
+}
+
+// A validation interrupted between the reserve and the terminal write
+// leaves the challenge processing with no owner. RFC 8555 Section 7.1.6
+// clients respond to a challenge once and then poll — they never re-POST
+// the attestation — so once the lease lapses a poll must present the
+// challenge as pending again, the way handleOrder re-presents a lapsed
+// processing order as ready, or the order wedges for polling clients.
+func TestStrandedChallengeRecoversByPolling(t *testing.T) {
+	t.Parallel()
+
+	storage := &challengeValidFailingOnceStorage{Storage: newTestStorage(t)}
+	ts := newShortLeaseTestServer(t, storage, nil)
+
+	client := newACMEClient(t, ts)
+	_, chal := pendingChallenge(t, client, "poll-only-device")
+	if err := submitAttObj(t, client, chal, nullAttObj(t)); err == nil {
+		t.Fatal("Accept() error = nil, want failure from interrupted validation")
+	}
+
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		got, err := client.GetChallenge(t.Context(), chal.URI)
+		if err != nil {
+			t.Fatalf("GetChallenge() error = %v", err)
+		}
+		if got.Status == acme.StatusPending {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("challenge status polled after abandoned validation = %q, want %q", got.Status, acme.StatusPending)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+type failOnceAuthorizer struct {
+	mu     sync.Mutex
+	failed bool
+}
+
+func (a *failOnceAuthorizer) Authorize(context.Context, *nanoca.DeviceInfo) (bool, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if !a.failed {
+		a.failed = true
+		return false, errors.New("authorizer unavailable")
+	}
+	return true, nil
+}
+
+// An authorizer error is a backend condition (the ABM authorizer calls a
+// network API), and failOrder keeps 5xx-class finalize failures retriable
+// for exactly that reason. A one-off authorizer outage must not durably
+// invalidate the challenge — and with it the authorization and order —
+// when a retry after the outage would succeed.
+func TestChallengeSurvivesTransientAuthorizerError(t *testing.T) {
+	t.Parallel()
+
+	ts, _ := newTestServer(t, testServerConfig{authorizer: &failOnceAuthorizer{}})
+	client := newACMEClient(t, ts)
+
+	_, chal := pendingChallenge(t, client, "authz-outage-device")
+	if err := submitAttObj(t, client, chal, nullAttObj(t)); err == nil {
+		t.Fatal("Accept() error = nil, want failure from authorizer outage")
+	}
+
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		_ = submitAttObj(t, client, chal, nullAttObj(t))
+		got, err := client.GetChallenge(t.Context(), chal.URI)
+		if err != nil {
+			t.Fatalf("GetChallenge() error = %v", err)
+		}
+		if got.Status == acme.StatusValid {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("challenge status after authorizer recovery = %q, want %q", got.Status, acme.StatusValid)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// flakyReverifyVerifier succeeds at challenge time, fails once at finalize
+// re-verification, then succeeds again — a pluggable verifier that does
+// I/O (revocation fetch, TPM CA lookup) behaves this way during a
+// transient outage.
+type flakyReverifyVerifier struct {
+	mu    sync.Mutex
+	calls int
+}
+
+func (v *flakyReverifyVerifier) Format() string { return "flaky" }
+
+func (v *flakyReverifyVerifier) Verify(context.Context, nanoca.AttestationStatement, []byte) (*nanoca.DeviceInfo, error) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.calls++
+	if v.calls == 2 {
+		return nil, errors.New("verifier unavailable")
+	}
+	return &nanoca.DeviceInfo{
+		PermanentIdentifier: &nanoca.PermanentIdentifier{Identifier: "flaky-device"},
+	}, nil
+}
+
+// The order only reached ready through a successful attestation, so a
+// transient re-verification failure at finalize can clear on retry; moving
+// the order to invalid forces the device to restart enrollment for a
+// failure it did not cause.
+func TestFinalizeRetryAfterTransientVerifierError(t *testing.T) {
+	t.Parallel()
+
+	ts, _ := newTestServer(t, testServerConfig{verifiers: []nanoca.AttestationVerifier{&flakyReverifyVerifier{}}})
+	client := newACMEClient(t, ts)
+
+	order, chal := pendingChallenge(t, client, "flaky-verify-device")
+	if err := submitAttObj(t, client, chal, attObjFor(t, "flaky")); err != nil {
+		t.Fatalf("failed to satisfy challenge: %v", err)
+	}
+
+	if _, _, err := client.CreateOrderCert(t.Context(), order.FinalizeURL, newCSR(t), true); err == nil {
+		t.Fatal("CreateOrderCert() error = nil, want re-verification failure")
+	}
+
+	deadline := time.Now().Add(3 * time.Second)
+	var err error
+	for {
+		_, _, err = client.CreateOrderCert(t.Context(), order.FinalizeURL, newCSR(t), true)
+		if err == nil || time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if err != nil {
+		t.Errorf("retried CreateOrderCert() after transient verifier error = %v, want success", err)
+	}
+}
+
+// Once the authorization is valid, promoting the order must not hinge on a
+// single SetOrderStatus write succeeding: re-POSTs of the valid challenge
+// short-circuit before recomputing, and updateAuthorizationStatus returns
+// early on the settled authorization, so nothing ever retries the
+// pending-to-ready transition and the order polls pending forever.
+func TestOrderReadyRetriesAfterStatusWriteFailure(t *testing.T) {
+	t.Parallel()
+
+	storage := &orderWriteFailingStorage{Storage: newTestStorage(t)}
+	ts := newStorageTestServer(t, storage, nil)
+
+	client := newACMEClient(t, ts)
+	order, chal := pendingChallenge(t, client, "promotion-device")
+
+	storage.setFail(true)
+	if err := submitAttObj(t, client, chal, nullAttObj(t)); err != nil {
+		t.Fatalf("failed to satisfy challenge: %v", err)
+	}
+	storage.setFail(false)
+
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		_ = submitAttObj(t, client, chal, nullAttObj(t))
+		polled, err := client.GetOrder(t.Context(), order.URI)
+		if err != nil {
+			t.Fatalf("GetOrder() error = %v", err)
+		}
+		if polled.Status == acme.StatusReady {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("order status after storage heals = %q, want %q", polled.Status, acme.StatusReady)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// challengeInvalidFailingStorage fails SetChallengeInvalid with a plain
+// backend error while armed, so failChallenge takes its non-fencing branch
+// and never learns another request has claimed the challenge.
+type challengeInvalidFailingStorage struct {
+	nanoca.Storage
+	mu    sync.Mutex
+	armed bool
+}
+
+func (s *challengeInvalidFailingStorage) arm() {
+	s.mu.Lock()
+	s.armed = true
+	s.mu.Unlock()
+}
+
+func (s *challengeInvalidFailingStorage) SetChallengeInvalid(ctx context.Context, id, reservationToken string, validated time.Time, problem *nanoca.Problem) error {
+	s.mu.Lock()
+	armed := s.armed
+	s.mu.Unlock()
+	if armed {
+		return errors.New("backend unavailable")
+	}
+	return s.Storage.SetChallengeInvalid(ctx, id, reservationToken, validated, problem)
+}
+
+// A zombie can also lose its claim without being told: when its fenced
+// SetChallengeInvalid fails with a backend error instead of a fencing
+// rejection, it goes on to recompute the authorization from reads taken
+// before the reclaiming retry settled. That stale write must not revert
+// the settled authorization any more than the fencing-rejection variant
+// (TestZombieInvalidationDoesNotRevertSettledAuthz) may.
+func TestZombieBackendErrorDoesNotRevertSettledAuthz(t *testing.T) {
+	t.Parallel()
+
+	verifier := newGateVerifier()
+	failing := &challengeInvalidFailingStorage{Storage: newTestStorage(t)}
+	storage := &authzWriteParkingStorage{Storage: failing, parked: make(chan chan struct{}, 1)}
+	ts, _ := newTestServer(t, testServerConfig{
+		storage:   storage,
+		opts:      []nanoca.Option{nanoca.WithReservationLease(testReservationLease)},
+		verifiers: []nanoca.AttestationVerifier{verifier},
+	})
+
+	client := newACMEClient(t, ts)
+	order, chal := pendingChallenge(t, client, "zombie-backend-device")
+
+	payload, err := json.Marshal(map[string]any{"attObj": attObjFor(t, "gate")})
+	if err != nil {
+		t.Fatalf("failed to marshal payload: %v", err)
+	}
+	chal.Payload = payload
+
+	zombieDone := make(chan error, 1)
+	go func() {
+		_, err := client.Accept(t.Context(), chal)
+		zombieDone <- err
+	}()
+	<-verifier.entered[0]
+
+	// The zombie holds the reservation inside its verifier; once the lease
+	// lapses, the retry reclaims it and parks inside its own verifier.
+	time.Sleep(2 * testReservationLease)
+	retryDone := make(chan error, 1)
+	go func() {
+		_, err := client.Accept(t.Context(), chal)
+		retryDone <- err
+	}()
+	<-verifier.entered[1]
+
+	// The zombie fails verification while the retry holds the reservation,
+	// but its SetChallengeInvalid reports a backend error, not the fencing
+	// rejection. If it recomputes the authorization anyway, its stale
+	// write parks; if it treats the lost claim as settled, it finishes
+	// without writing.
+	failing.arm()
+	storage.park(1)
+	close(verifier.release[0])
+	var gate chan struct{}
+	select {
+	case gate = <-storage.parked:
+	case <-zombieDone:
+		storage.park(0)
+	}
+
+	close(verifier.release[1])
+	if err := <-retryDone; err != nil {
+		t.Fatalf("reclaiming Accept() error = %v, want success", err)
+	}
+
+	// The retry has settled: challenge valid, authorization valid, order
+	// ready. Any parked zombie write lands last.
+	if gate != nil {
+		close(gate)
+		<-zombieDone
+	}
+
+	authz, err := client.GetAuthorization(t.Context(), order.AuthzURLs[0])
+	if err != nil {
+		t.Fatalf("GetAuthorization() error = %v", err)
+	}
+	if authz.Status != acme.StatusValid {
+		t.Errorf("authorization status after zombie write = %q, want %q", authz.Status, acme.StatusValid)
+	}
+}
+
+// authzSettleFailingStorage fails authorization settles while armed,
+// simulating a backend outage that begins between a challenge's terminal
+// write and the authorization promotion that follows.
+type authzSettleFailingStorage struct {
+	nanoca.Storage
+	mu   sync.Mutex
+	fail bool
+}
+
+func (s *authzSettleFailingStorage) setFail(fail bool) {
+	s.mu.Lock()
+	s.fail = fail
+	s.mu.Unlock()
+}
+
+func (s *authzSettleFailingStorage) SettleAuthorization(ctx context.Context, authz *nanoca.Authorization) error {
+	s.mu.Lock()
+	fail := s.fail
+	s.mu.Unlock()
+	if fail {
+		return errors.New("backend unavailable")
+	}
+	return s.Storage.SettleAuthorization(ctx, authz)
+}
+
+// Once the challenge is valid, promoting the authorization must not hinge
+// on a single settle write succeeding: re-POSTs of the valid challenge
+// short-circuit the validation path, and order polls recompute only from
+// the authorization's stored status, so without a retry hook the order
+// wedges — the same trap the order leg escapes in
+// TestOrderReadyRetriesAfterStatusWriteFailure.
+func TestAuthzPromotionRetriesAfterWriteFailure(t *testing.T) {
+	t.Parallel()
+
+	storage := &authzSettleFailingStorage{Storage: newTestStorage(t)}
+	ts := newStorageTestServer(t, storage, nil)
+
+	client := newACMEClient(t, ts)
+	order, chal := pendingChallenge(t, client, "authz-promotion-device")
+
+	storage.setFail(true)
+	if err := submitAttObj(t, client, chal, nullAttObj(t)); err != nil {
+		t.Fatalf("failed to satisfy challenge: %v", err)
+	}
+	storage.setFail(false)
+
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		_ = submitAttObj(t, client, chal, nullAttObj(t))
+		polled, err := client.GetOrder(t.Context(), order.URI)
+		if err != nil {
+			t.Fatalf("GetOrder() error = %v", err)
+		}
+		if polled.Status == acme.StatusReady {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("order status after storage heals = %q, want %q", polled.Status, acme.StatusReady)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// An RFC 8555 Section 7.5.1 client watches the authorization object, not the
+// challenge URL — x/crypto/acme's WaitAuthorization never re-reads the
+// challenge directly. The lease-lapse presentation handleChallenge applies
+// must therefore reach the authorization view too: a challenge stranded in
+// processing by an interrupted validation has to read as pending in the
+// embedded copy once the lease lapses, or authorization-polling clients
+// wedge forever (TestStrandedChallengeRecoversByPolling covers the
+// challenge-URL leg).
+func TestStrandedChallengeRecoversByAuthzPolling(t *testing.T) {
+	t.Parallel()
+
+	storage := &challengeValidFailingOnceStorage{Storage: newTestStorage(t)}
+	ts := newShortLeaseTestServer(t, storage, nil)
+
+	client := newACMEClient(t, ts)
+	order, chal := pendingChallenge(t, client, "authz-poll-only-device")
+	if err := submitAttObj(t, client, chal, nullAttObj(t)); err == nil {
+		t.Fatal("Accept() error = nil, want failure from interrupted validation")
+	}
+
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		authz, err := client.GetAuthorization(t.Context(), order.AuthzURLs[0])
+		if err != nil {
+			t.Fatalf("GetAuthorization() error = %v", err)
+		}
+		if authz.Challenges[0].Status == acme.StatusPending {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("challenge status in polled authorization after abandoned validation = %q, want %q",
+				authz.Challenges[0].Status, acme.StatusPending)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/handlers_storage_test.go
+++ b/handlers_storage_test.go
@@ -1,0 +1,1233 @@
+package nanoca_test
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/asn1"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"path"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/brandonweeks/nanoca"
+	"golang.org/x/crypto/acme"
+)
+
+type accountLookupFailingStorage struct {
+	nanoca.Storage
+}
+
+func (accountLookupFailingStorage) GetAccountByKey(context.Context, string) (*nanoca.Account, error) {
+	return nil, errors.New("backend unavailable")
+}
+
+type accountCreateRacingStorage struct {
+	nanoca.Storage
+	raced bool
+}
+
+func (s *accountCreateRacingStorage) CreateAccount(ctx context.Context, account *nanoca.Account) error {
+	if s.raced {
+		return s.Storage.CreateAccount(ctx, account)
+	}
+	s.raced = true
+
+	winner := *account
+	winner.ID = "concurrent-winner"
+	if err := s.Storage.CreateAccount(ctx, &winner); err != nil {
+		return err
+	}
+	return nanoca.ErrAccountExists
+}
+
+type orderLookupFailingStorage struct {
+	nanoca.Storage
+}
+
+func (orderLookupFailingStorage) GetOrder(context.Context, string) (*nanoca.Order, error) {
+	return nil, errors.New("backend unavailable")
+}
+
+type orderCreateFailingStorage struct {
+	nanoca.Storage
+}
+
+func (orderCreateFailingStorage) CreateOrder(context.Context, *nanoca.Order) error {
+	return errors.New("backend unavailable")
+}
+
+type orderCreateNotFoundStorage struct {
+	nanoca.Storage
+}
+
+func (orderCreateNotFoundStorage) CreateOrder(context.Context, *nanoca.Order) error {
+	return fmt.Errorf("parent record missing: %w", nanoca.ErrNotFound)
+}
+
+// orderVanishingStorage drops the order once finalize has persisted it as
+// valid, simulating a backend where the re-read after finalize misses.
+type orderVanishingStorage struct {
+	nanoca.Storage
+	mu       sync.Mutex
+	vanished bool
+}
+
+func (s *orderVanishingStorage) CompleteOrder(ctx context.Context, order *nanoca.Order, cert *nanoca.Certificate, token string) error {
+	err := s.Storage.CompleteOrder(ctx, order, cert, token)
+	if err == nil {
+		s.mu.Lock()
+		s.vanished = true
+		s.mu.Unlock()
+	}
+	return err
+}
+
+func (s *orderVanishingStorage) GetOrder(ctx context.Context, id string) (*nanoca.Order, error) {
+	s.mu.Lock()
+	vanished := s.vanished
+	s.mu.Unlock()
+	if vanished {
+		return nil, nanoca.ErrNotFound
+	}
+	return s.Storage.GetOrder(ctx, id)
+}
+
+// authzLookupFailingStorage serves the challenge flow normally, then fails
+// authorization lookups once armed, simulating a backend outage that begins
+// between challenge validation and finalize.
+type authzLookupFailingStorage struct {
+	nanoca.Storage
+	mu   sync.Mutex
+	fail bool
+}
+
+func (s *authzLookupFailingStorage) failLookups() {
+	s.mu.Lock()
+	s.fail = true
+	s.mu.Unlock()
+}
+
+func (s *authzLookupFailingStorage) GetAuthorization(ctx context.Context, id string) (*nanoca.Authorization, error) {
+	s.mu.Lock()
+	fail := s.fail
+	s.mu.Unlock()
+	if fail {
+		return nil, errors.New("backend unavailable")
+	}
+	return s.Storage.GetAuthorization(ctx, id)
+}
+
+// completeOrderFailingOnceStorage fails the first atomic completion, after
+// the certificate has been signed but before anything is persisted.
+type completeOrderFailingOnceStorage struct {
+	nanoca.Storage
+	mu     sync.Mutex
+	failed bool
+}
+
+func (s *completeOrderFailingOnceStorage) CompleteOrder(ctx context.Context, order *nanoca.Order, cert *nanoca.Certificate, token string) error {
+	s.mu.Lock()
+	first := !s.failed
+	s.failed = true
+	s.mu.Unlock()
+	if first {
+		return errors.New("backend unavailable")
+	}
+	return s.Storage.CompleteOrder(ctx, order, cert, token)
+}
+
+type selfSignedIssuer struct{}
+
+func (selfSignedIssuer) IssueCertificate(_ context.Context, csr *x509.CertificateRequest, _ []*nanoca.DeviceInfo) (*nanoca.Certificate, error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+	tmpl := &x509.Certificate{SerialNumber: big.NewInt(1), Subject: csr.Subject}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, csr.PublicKey, key)
+	if err != nil {
+		return nil, err
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		return nil, err
+	}
+	return &nanoca.Certificate{Certificate: cert, Raw: der, SerialNumber: "1"}, nil
+}
+
+type nonceConsumeFailingStorage struct {
+	nanoca.Storage
+}
+
+func (nonceConsumeFailingStorage) ConsumeNonce(context.Context, string, time.Duration) (*nanoca.Nonce, error) {
+	return nil, errors.New("backend unavailable")
+}
+
+func newStorageTestServer(t *testing.T, storage nanoca.Storage, issuer nanoca.CertificateIssuer) *httptest.Server {
+	t.Helper()
+	ts, _ := newTestServer(t, testServerConfig{issuer: issuer, storage: storage})
+	return ts
+}
+
+// testReservationLease is short enough that lease-expiry tests converge
+// quickly but long enough that a reservation is observably live first.
+const testReservationLease = 25 * time.Millisecond
+
+func newShortLeaseTestServer(t *testing.T, storage nanoca.Storage, issuer nanoca.CertificateIssuer) *httptest.Server {
+	t.Helper()
+	ts, _ := newTestServer(t, testServerConfig{
+		issuer:  issuer,
+		storage: storage,
+		opts:    []nanoca.Option{nanoca.WithReservationLease(testReservationLease)},
+	})
+	return ts
+}
+
+func newFailingStorageClient(t *testing.T, storage nanoca.Storage) *acme.Client {
+	t.Helper()
+	return newUnregisteredClient(t, newStorageTestServer(t, storage, stubIssuer{}))
+}
+
+func wantServerInternal(t *testing.T, err error) {
+	t.Helper()
+
+	var ae *acme.Error
+	if !errors.As(err, &ae) {
+		t.Fatalf("error = %v, want *acme.Error", err)
+	}
+	if ae.StatusCode != http.StatusInternalServerError {
+		t.Errorf("status = %d, want %d", ae.StatusCode, http.StatusInternalServerError)
+	}
+	if ae.ProblemType != "urn:ietf:params:acme:error:serverInternal" {
+		t.Errorf("problem type = %q, want serverInternal", ae.ProblemType)
+	}
+}
+
+// A storage failure during account lookup must surface as serverInternal, not
+// fall through to creating a fresh account for an already-registered key.
+func TestNewAccountStorageFailure(t *testing.T) {
+	t.Parallel()
+
+	client := newFailingStorageClient(t, accountLookupFailingStorage{Storage: newTestStorage(t)})
+
+	_, err := client.Register(t.Context(), &acme.Account{}, acme.AcceptTOS)
+	wantServerInternal(t, err)
+}
+
+// Losing the create race to a concurrent registration of the same key must
+// return the winning account (200), not serverInternal.
+func TestNewAccountCreateRace(t *testing.T) {
+	t.Parallel()
+
+	client := newFailingStorageClient(t, &accountCreateRacingStorage{Storage: newTestStorage(t)})
+
+	_, err := client.Register(t.Context(), &acme.Account{}, acme.AcceptTOS)
+	if !errors.Is(err, acme.ErrAccountAlreadyExists) {
+		t.Fatalf("Register() error = %v, want ErrAccountAlreadyExists", err)
+	}
+}
+
+// A storage failure while loading the order during finalize must surface as
+// serverInternal; a 400 would make clients abort the order as permanently
+// failed instead of retrying a transient outage.
+func TestFinalizeStorageFailure(t *testing.T) {
+	t.Parallel()
+
+	client := newFailingStorageClient(t, orderLookupFailingStorage{Storage: newTestStorage(t)})
+	if _, err := client.Register(t.Context(), &acme.Account{}, acme.AcceptTOS); err != nil {
+		t.Fatalf("failed to register account: %v", err)
+	}
+	order, err := client.AuthorizeOrder(t.Context(), []acme.AuthzID{{Type: "permanent-identifier", Value: "device"}})
+	if err != nil {
+		t.Fatalf("failed to create order: %v", err)
+	}
+
+	_, _, err = client.CreateOrderCert(t.Context(), order.FinalizeURL, newCSR(t), true)
+	wantServerInternal(t, err)
+}
+
+func TestNewOrderStorageFailure(t *testing.T) {
+	t.Parallel()
+
+	client := newFailingStorageClient(t, orderCreateFailingStorage{Storage: newTestStorage(t)})
+	if _, err := client.Register(t.Context(), &acme.Account{}, acme.AcceptTOS); err != nil {
+		t.Fatalf("failed to register account: %v", err)
+	}
+
+	_, err := client.AuthorizeOrder(t.Context(), []acme.AuthzID{{Type: "permanent-identifier", Value: "device"}})
+	wantServerInternal(t, err)
+}
+
+// An ErrNotFound wrapped out of CreateOrder is a backend failure, not proof
+// the account is gone: accountDoesNotExist makes clients discard their
+// registration and re-enroll.
+func TestNewOrderCreateNotFound(t *testing.T) {
+	t.Parallel()
+
+	client := newFailingStorageClient(t, orderCreateNotFoundStorage{Storage: newTestStorage(t)})
+	if _, err := client.Register(t.Context(), &acme.Account{}, acme.AcceptTOS); err != nil {
+		t.Fatalf("failed to register account: %v", err)
+	}
+
+	_, err := client.AuthorizeOrder(t.Context(), []acme.AuthzID{{Type: "permanent-identifier", Value: "device"}})
+	wantServerInternal(t, err)
+}
+
+// Once finalize has issued and stored the certificate, the response must not
+// depend on re-reading the order: a miss there returns a permanent-looking
+// 400 for an order that actually completed, stranding the issued cert.
+func TestFinalizeSurvivesOrderRereadFailure(t *testing.T) {
+	t.Parallel()
+
+	storage := &orderVanishingStorage{Storage: newTestStorage(t)}
+	ts := newStorageTestServer(t, storage, selfSignedIssuer{})
+
+	client := newACMEClient(t, ts)
+	order, chal := pendingChallenge(t, client, "vanishing-device")
+	if err := submitAttObj(t, client, chal, nullAttObj(t)); err != nil {
+		t.Fatalf("failed to satisfy challenge: %v", err)
+	}
+
+	cert, _, err := client.CreateOrderCert(t.Context(), order.FinalizeURL, newCSR(t), true)
+	if err != nil {
+		t.Fatalf("CreateOrderCert() error = %v, want success", err)
+	}
+	if len(cert) == 0 {
+		t.Error("CreateOrderCert() returned no certificate")
+	}
+}
+
+// A storage failure while finalize collects the verified device identity must
+// fail the request: silently issuing with an empty deviceInfos strips the
+// permanent-identifier/hardware-module SANs from the certificate of a device
+// whose attestation already succeeded.
+func TestFinalizeDeviceInfoStorageFailure(t *testing.T) {
+	t.Parallel()
+
+	storage := &authzLookupFailingStorage{Storage: newTestStorage(t)}
+	ts := newStorageTestServer(t, storage, selfSignedIssuer{})
+
+	client := newACMEClient(t, ts)
+	order, chal := pendingChallenge(t, client, "attested-device")
+	if err := submitAttObj(t, client, chal, nullAttObj(t)); err != nil {
+		t.Fatalf("failed to satisfy challenge: %v", err)
+	}
+
+	storage.failLookups()
+	_, _, err := client.CreateOrderCert(t.Context(), order.FinalizeURL, newCSR(t), true)
+	wantServerInternal(t, err)
+}
+
+// A failed completion persists nothing: the signed certificate is discarded
+// and the order stays ready, so a retry — even with a regenerated key —
+// gets a fresh certificate for the CSR it actually carries. Once the order
+// is valid, further finalizes are refused per RFC 8555 Section 7.4 rather
+// than answered with the stored certificate.
+func TestFinalizeRetryAfterCompletionFailure(t *testing.T) {
+	t.Parallel()
+
+	storage := &completeOrderFailingOnceStorage{Storage: newTestStorage(t)}
+	ts := newStorageTestServer(t, storage, selfSignedIssuer{})
+
+	client := newACMEClient(t, ts)
+	order, chal := pendingChallenge(t, client, "retry-device")
+	if err := submitAttObj(t, client, chal, nullAttObj(t)); err != nil {
+		t.Fatalf("failed to satisfy challenge: %v", err)
+	}
+
+	_, _, err := client.CreateOrderCert(t.Context(), order.FinalizeURL, newCSR(t), true)
+	wantServerInternal(t, err)
+
+	// The client regenerated its key before retrying.
+	retryCSR := newCSR(t)
+	chain, _, err := client.CreateOrderCert(t.Context(), order.FinalizeURL, retryCSR, true)
+	if err != nil {
+		t.Fatalf("retried CreateOrderCert() error = %v", err)
+	}
+	csr, err := x509.ParseCertificateRequest(retryCSR)
+	if err != nil {
+		t.Fatalf("failed to parse CSR: %v", err)
+	}
+	cert, err := x509.ParseCertificate(chain[0])
+	if err != nil {
+		t.Fatalf("failed to parse certificate: %v", err)
+	}
+	key, ok := cert.PublicKey.(*ecdsa.PublicKey)
+	if !ok {
+		t.Fatalf("certificate public key type = %T, want *ecdsa.PublicKey", cert.PublicKey)
+	}
+	if !key.Equal(csr.PublicKey) {
+		t.Error("finalize returned a certificate for a different key than the submitted CSR")
+	}
+
+	_, _, err = client.CreateOrderCert(t.Context(), order.FinalizeURL, retryCSR, true)
+	var ae *acme.Error
+	if !errors.As(err, &ae) || ae.ProblemType != "urn:ietf:params:acme:error:orderNotReady" {
+		t.Errorf("finalize after valid error = %v, want orderNotReady", err)
+	}
+}
+
+// A nonce-storage failure must surface as serverInternal, not badNonce:
+// clients respond to badNonce by retrying immediately with a fresh nonce,
+// hammering a backend that is already down.
+func TestNonceStorageFailure(t *testing.T) {
+	t.Parallel()
+
+	client := newFailingStorageClient(t, nonceConsumeFailingStorage{Storage: newTestStorage(t)})
+
+	_, err := client.Register(t.Context(), &acme.Account{}, acme.AcceptTOS)
+	wantServerInternal(t, err)
+}
+
+// rendezvousIssuer holds the first issuance open until a second concurrent
+// call arrives (or a timeout passes), maximizing the window between the
+// stored-certificate check and the certificate write.
+type rendezvousIssuer struct {
+	selfSignedIssuer
+	mu    sync.Mutex
+	calls int
+	both  chan struct{}
+}
+
+func (i *rendezvousIssuer) IssueCertificate(ctx context.Context, csr *x509.CertificateRequest, infos []*nanoca.DeviceInfo) (*nanoca.Certificate, error) {
+	i.mu.Lock()
+	i.calls++
+	if i.calls == 2 {
+		close(i.both)
+	}
+	i.mu.Unlock()
+	select {
+	case <-i.both:
+	case <-time.After(time.Second):
+	}
+	return i.selfSignedIssuer.IssueCertificate(ctx, csr, infos)
+}
+
+// Concurrent finalize POSTs for one ready order (a retry racing a slow
+// first request) must not each sign a certificate: a doubled issuance
+// leaves a CA-signed certificate with no storage record.
+func TestFinalizeConcurrentIssuesOnce(t *testing.T) {
+	t.Parallel()
+
+	issuer := &rendezvousIssuer{both: make(chan struct{})}
+	ts := newStorageTestServer(t, newTestStorage(t), issuer)
+
+	client := newACMEClient(t, ts)
+	order, chal := pendingChallenge(t, client, "concurrent-device")
+	if err := submitAttObj(t, client, chal, nullAttObj(t)); err != nil {
+		t.Fatalf("failed to satisfy challenge: %v", err)
+	}
+
+	csrs := [][]byte{newCSR(t), newCSR(t)}
+	errs := make(chan error, len(csrs))
+	var wg sync.WaitGroup
+	for _, csr := range csrs {
+		wg.Go(func() {
+			_, _, err := client.CreateOrderCert(t.Context(), order.FinalizeURL, csr, true)
+			errs <- err
+		})
+	}
+	wg.Wait()
+	close(errs)
+
+	failures := 0
+	for err := range errs {
+		if err != nil {
+			failures++
+			t.Logf("CreateOrderCert() error = %v", err)
+		}
+	}
+	if failures == len(csrs) {
+		t.Error("every concurrent finalize failed, want at least one success")
+	}
+
+	issuer.mu.Lock()
+	calls := issuer.calls
+	issuer.mu.Unlock()
+	if calls != 1 {
+		t.Errorf("IssueCertificate calls = %d, want 1", calls)
+	}
+}
+
+// challengeRendezvousStorage, once armed, holds reads of a pending
+// challenge until two concurrent readers arrive, so both duplicate POSTs
+// pass the handler's pending-status guard together.
+type challengeRendezvousStorage struct {
+	nanoca.Storage
+	mu      sync.Mutex
+	armed   bool
+	readers int
+	both    chan struct{}
+}
+
+func (s *challengeRendezvousStorage) arm() {
+	s.mu.Lock()
+	s.armed = true
+	s.mu.Unlock()
+}
+
+func (s *challengeRendezvousStorage) GetChallenge(ctx context.Context, id string) (*nanoca.Challenge, error) {
+	challenge, err := s.Storage.GetChallenge(ctx, id)
+	if err != nil || challenge.Status != nanoca.ChallengeStatusPending {
+		return challenge, err
+	}
+	s.mu.Lock()
+	if !s.armed {
+		s.mu.Unlock()
+		return challenge, nil
+	}
+	s.readers++
+	if s.readers == 2 {
+		close(s.both)
+	}
+	s.mu.Unlock()
+	select {
+	case <-s.both:
+	case <-time.After(2 * time.Second):
+	}
+	return challenge, nil
+}
+
+// Duplicate challenge POSTs can also race: both read "pending" before
+// either marks the challenge processing, and the loser must still get the
+// current state, not a retriable 500 (TestChallengeDuplicateSubmission
+// covers the sequential case).
+func TestChallengeConcurrentDuplicateSubmission(t *testing.T) {
+	t.Parallel()
+
+	storage := &challengeRendezvousStorage{Storage: newTestStorage(t), both: make(chan struct{})}
+	ts := newStorageTestServer(t, storage, stubIssuer{})
+
+	client := newACMEClient(t, ts)
+	_, chal := pendingChallenge(t, client, "racing-device")
+
+	payload, err := json.Marshal(map[string]any{"attObj": nullAttObj(t)})
+	if err != nil {
+		t.Fatalf("failed to marshal payload: %v", err)
+	}
+	chal.Payload = payload
+
+	storage.arm()
+	errs := make(chan error, 2)
+	var wg sync.WaitGroup
+	for range 2 {
+		wg.Go(func() {
+			_, err := client.Accept(t.Context(), chal)
+			errs <- err
+		})
+	}
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		var ae *acme.Error
+		if errors.As(err, &ae) && ae.StatusCode >= http.StatusInternalServerError {
+			t.Errorf("concurrent duplicate challenge POST status = %d, want non-5xx", ae.StatusCode)
+		}
+	}
+}
+
+// corruptAttestationStorage persists a truncated attestation, simulating a
+// stored record (e.g. one written before the current format) that can no
+// longer be decoded.
+type corruptAttestationStorage struct {
+	nanoca.Storage
+}
+
+func (s corruptAttestationStorage) SetChallengeValid(ctx context.Context, id, reservationToken string, validated time.Time, attestation []byte) error {
+	return s.Storage.SetChallengeValid(ctx, id, reservationToken, validated, attestation[:1])
+}
+
+// An order whose stored attestation can never be re-verified is stuck: a
+// 5xx invites the client to retry an operation that cannot succeed, so the
+// failure must surface as a terminal problem.
+func TestFinalizeUnreadableAttestationTerminal(t *testing.T) {
+	t.Parallel()
+
+	storage := corruptAttestationStorage{Storage: newTestStorage(t)}
+	ts := newStorageTestServer(t, storage, selfSignedIssuer{})
+
+	client := newACMEClient(t, ts)
+	order, chal := pendingChallenge(t, client, "legacy-device")
+	if err := submitAttObj(t, client, chal, nullAttObj(t)); err != nil {
+		t.Fatalf("failed to satisfy challenge: %v", err)
+	}
+
+	_, _, err := client.CreateOrderCert(t.Context(), order.FinalizeURL, newCSR(t), true)
+	var ae *acme.Error
+	if !errors.As(err, &ae) {
+		t.Fatalf("CreateOrderCert() error = %v, want *acme.Error", err)
+	}
+	if ae.StatusCode >= http.StatusInternalServerError {
+		t.Errorf("finalize status = %d, want terminal non-5xx", ae.StatusCode)
+	}
+
+	// RFC 8555 Section 7.1.6: an error during finalization moves the order to
+	// "invalid". Returning it to "ready" tells a polling client to submit the
+	// same doomed finalize again, forever.
+	got, err := client.GetOrder(t.Context(), order.URI)
+	if err != nil {
+		t.Fatalf("GetOrder() error = %v", err)
+	}
+	if got.Status != acme.StatusInvalid {
+		t.Errorf("order status after terminal finalize failure = %q, want %q", got.Status, acme.StatusInvalid)
+	}
+}
+
+// orderReadParkingStorage parks armed GetOrder calls until the test releases
+// them, holding a challenge handler open between its authorization update and
+// the order-status write that follows.
+type orderReadParkingStorage struct {
+	nanoca.Storage
+	mu     sync.Mutex
+	toPark int
+	parked chan chan struct{}
+}
+
+func (s *orderReadParkingStorage) park(n int) {
+	s.mu.Lock()
+	s.toPark = n
+	s.mu.Unlock()
+}
+
+func (s *orderReadParkingStorage) GetOrder(ctx context.Context, id string) (*nanoca.Order, error) {
+	s.mu.Lock()
+	if s.toPark > 0 {
+		s.toPark--
+		s.mu.Unlock()
+		gate := make(chan struct{})
+		s.parked <- gate
+		<-gate
+	} else {
+		s.mu.Unlock()
+	}
+	return s.Storage.GetOrder(ctx, id)
+}
+
+// gatedIssuer holds its first issuance open so a finalize stays in flight
+// until the test releases it.
+type gatedIssuer struct {
+	selfSignedIssuer
+	mu      sync.Mutex
+	calls   int
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (i *gatedIssuer) IssueCertificate(ctx context.Context, csr *x509.CertificateRequest, infos []*nanoca.DeviceInfo) (*nanoca.Certificate, error) {
+	i.mu.Lock()
+	i.calls++
+	first := i.calls == 1
+	i.mu.Unlock()
+	if first {
+		close(i.entered)
+		<-i.release
+	}
+	return i.selfSignedIssuer.IssueCertificate(ctx, csr, infos)
+}
+
+// A challenge handler's authorization-settling write that lands after a
+// finalize has begun must not disturb the order: reverting it to ready mid-
+// issuance discards the signed certificate, or lets a repeat finalize issue
+// a second one.
+func TestFinalizeReservationSurvivesAuthzUpdate(t *testing.T) {
+	t.Parallel()
+
+	storage := &orderReadParkingStorage{Storage: newTestStorage(t), parked: make(chan chan struct{}, 2)}
+	issuer := &gatedIssuer{entered: make(chan struct{}), release: make(chan struct{})}
+	ts := newStorageTestServer(t, storage, issuer)
+
+	client := newACMEClient(t, ts)
+	order, err := client.AuthorizeOrder(t.Context(), []acme.AuthzID{
+		{Type: "permanent-identifier", Value: "device-a"},
+		{Type: "permanent-identifier", Value: "device-b"},
+	})
+	if err != nil {
+		t.Fatalf("failed to create order: %v", err)
+	}
+
+	payload, err := json.Marshal(map[string]any{"attObj": nullAttObj(t)})
+	if err != nil {
+		t.Fatalf("failed to marshal payload: %v", err)
+	}
+
+	storage.park(2)
+	posted := make(chan error, 2)
+	for _, authzURL := range order.AuthzURLs {
+		authz, err := client.GetAuthorization(t.Context(), authzURL)
+		if err != nil {
+			t.Fatalf("failed to get authorization: %v", err)
+		}
+		chal := authz.Challenges[0]
+		chal.Payload = payload
+		go func() {
+			_, err := client.Accept(t.Context(), chal)
+			posted <- err
+		}()
+	}
+
+	// Both handlers have committed their authorization valid and are parked
+	// before reading the order; releasing one moves the order to ready.
+	gate1 := <-storage.parked
+	gate2 := <-storage.parked
+	close(gate1)
+	if err := <-posted; err != nil {
+		t.Fatalf("failed to satisfy challenge: %v", err)
+	}
+
+	csr := newCSR(t)
+	finalized := make(chan error, 1)
+	go func() {
+		_, _, err := client.CreateOrderCert(t.Context(), order.FinalizeURL, csr, true)
+		finalized <- err
+	}()
+	<-issuer.entered
+
+	// The reservation is now held; the parked handler commits its stale
+	// order-status write before issuance completes.
+	close(gate2)
+	if err := <-posted; err != nil {
+		t.Fatalf("failed to satisfy challenge: %v", err)
+	}
+	close(issuer.release)
+
+	if err := <-finalized; err != nil {
+		t.Errorf("CreateOrderCert() error = %v, want success despite concurrent authorization update", err)
+	}
+}
+
+// RFC 8555 Section 7.4: "processing" tells a polling client the certificate
+// is being issued and to poll again; "ready" tells it to submit a finalize,
+// which during issuance would only draw 403 orderNotReady.
+func TestOrderPollsProcessingDuringFinalize(t *testing.T) {
+	t.Parallel()
+
+	issuer := &gatedIssuer{entered: make(chan struct{}), release: make(chan struct{})}
+	ts := newStorageTestServer(t, newTestStorage(t), issuer)
+
+	client := newACMEClient(t, ts)
+	order, chal := pendingChallenge(t, client, "polling-device")
+	if err := submitAttObj(t, client, chal, nullAttObj(t)); err != nil {
+		t.Fatalf("failed to satisfy challenge: %v", err)
+	}
+
+	csr := newCSR(t)
+	finalized := make(chan error, 1)
+	go func() {
+		_, _, err := client.CreateOrderCert(t.Context(), order.FinalizeURL, csr, true)
+		finalized <- err
+	}()
+	<-issuer.entered
+
+	polled, err := client.GetOrder(t.Context(), order.URI)
+	if err != nil {
+		t.Fatalf("GetOrder() error = %v", err)
+	}
+	if polled.Status != acme.StatusProcessing {
+		t.Errorf("order status during finalize = %q, want %q", polled.Status, acme.StatusProcessing)
+	}
+
+	close(issuer.release)
+	if err := <-finalized; err != nil {
+		t.Fatalf("CreateOrderCert() error = %v", err)
+	}
+}
+
+// orderWriteFailingStorage fails order writes while armed, simulating a
+// backend outage that also takes out any cleanup write a failing finalize
+// attempts.
+type orderWriteFailingStorage struct {
+	nanoca.Storage
+	mu   sync.Mutex
+	fail bool
+}
+
+func (s *orderWriteFailingStorage) setFail(fail bool) {
+	s.mu.Lock()
+	s.fail = fail
+	s.mu.Unlock()
+}
+
+func (s *orderWriteFailingStorage) failing() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.fail
+}
+
+func (s *orderWriteFailingStorage) SetOrderStatus(ctx context.Context, id, from, to string) error {
+	if s.failing() {
+		return errors.New("backend unavailable")
+	}
+	return s.Storage.SetOrderStatus(ctx, id, from, to)
+}
+
+func (s *orderWriteFailingStorage) ReleaseOrderFinalize(ctx context.Context, id, token, to string) error {
+	if s.failing() {
+		return errors.New("backend unavailable")
+	}
+	return s.Storage.ReleaseOrderFinalize(ctx, id, token, to)
+}
+
+// failOnceIssuer fails the first issuance, as during a transient outage.
+type failOnceIssuer struct {
+	selfSignedIssuer
+	mu     sync.Mutex
+	failed bool
+}
+
+func (i *failOnceIssuer) IssueCertificate(ctx context.Context, csr *x509.CertificateRequest, infos []*nanoca.DeviceInfo) (*nanoca.Certificate, error) {
+	i.mu.Lock()
+	first := !i.failed
+	i.failed = true
+	i.mu.Unlock()
+	if first {
+		return nil, errors.New("issuer unavailable")
+	}
+	return i.selfSignedIssuer.IssueCertificate(ctx, csr, infos)
+}
+
+// A finalize that fails during a backend outage must not wedge the order in
+// an intermediate state: the failed release leaves it processing, so once
+// storage heals a retry has to be able to reclaim the lapsed reservation and
+// finalize instead of drawing 403 orderNotReady forever.
+func TestFinalizeRecoversAfterRollbackFailure(t *testing.T) {
+	t.Parallel()
+
+	storage := &orderWriteFailingStorage{Storage: newTestStorage(t)}
+	ts := newShortLeaseTestServer(t, storage, &failOnceIssuer{})
+
+	client := newACMEClient(t, ts)
+	order, chal := pendingChallenge(t, client, "outage-device")
+	if err := submitAttObj(t, client, chal, nullAttObj(t)); err != nil {
+		t.Fatalf("failed to satisfy challenge: %v", err)
+	}
+
+	storage.setFail(true)
+	_, _, err := client.CreateOrderCert(t.Context(), order.FinalizeURL, newCSR(t), true)
+	wantServerInternal(t, err)
+	storage.setFail(false)
+
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		_, _, err = client.CreateOrderCert(t.Context(), order.FinalizeURL, newCSR(t), true)
+		if err == nil || time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if err != nil {
+		t.Errorf("retried CreateOrderCert() after outage error = %v, want success", err)
+	}
+}
+
+// challengeValidFailingOnceStorage fails the first SetChallengeValid,
+// stranding a verified challenge in "processing" under a live reservation
+// the way a crash between the reserve and the terminal write would.
+type challengeValidFailingOnceStorage struct {
+	nanoca.Storage
+	mu     sync.Mutex
+	failed bool
+}
+
+func (s *challengeValidFailingOnceStorage) SetChallengeValid(ctx context.Context, id, reservationToken string, validated time.Time, attestation []byte) error {
+	s.mu.Lock()
+	first := !s.failed
+	s.failed = true
+	s.mu.Unlock()
+	if first {
+		return errors.New("backend unavailable")
+	}
+	return s.Storage.SetChallengeValid(ctx, id, reservationToken, validated, attestation)
+}
+
+// A challenge left in "processing" by an interrupted validation has no owner:
+// nothing retries it in the background, and re-submissions within the lease
+// are answered with 200 {"status":"processing"}. Once the lease lapses, the
+// client must be able to reclaim it and drive it to a terminal state, or its
+// order is silently wedged.
+func TestChallengeRecoversFromInterruptedValidation(t *testing.T) {
+	t.Parallel()
+
+	storage := &challengeValidFailingOnceStorage{Storage: newTestStorage(t)}
+	ts := newShortLeaseTestServer(t, storage, selfSignedIssuer{})
+
+	client := newACMEClient(t, ts)
+	_, chal := pendingChallenge(t, client, "interrupted-device")
+	if err := submitAttObj(t, client, chal, nullAttObj(t)); err == nil {
+		t.Fatal("Accept() error = nil, want failure from interrupted validation")
+	}
+
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		_ = submitAttObj(t, client, chal, nullAttObj(t))
+		got, err := client.GetChallenge(t.Context(), chal.URI)
+		if err != nil {
+			t.Fatalf("GetChallenge() error = %v", err)
+		}
+		if got.Status == acme.StatusValid {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("challenge status after re-submissions = %q, want %q", got.Status, acme.StatusValid)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// A finalize POST from an account that does not own the order must be turned
+// away before it takes the order's finalize reservation: while a foreign
+// request holds it, the owner draws 403 orderNotReady from its own finalize
+// and sees the order polling as "processing".
+func TestFinalizeForeignAccountDoesNotReserveOrder(t *testing.T) {
+	t.Parallel()
+
+	storage := &orderReadParkingStorage{Storage: newTestStorage(t), parked: make(chan chan struct{}, 1)}
+	ts := newStorageTestServer(t, storage, selfSignedIssuer{})
+
+	owner := newACMEClient(t, ts)
+	order, chal := pendingChallenge(t, owner, "owned-device")
+	if err := submitAttObj(t, owner, chal, nullAttObj(t)); err != nil {
+		t.Fatalf("failed to satisfy challenge: %v", err)
+	}
+
+	intruder := newACMEClient(t, ts)
+	intruderCSR := newCSR(t)
+	storage.park(1)
+	finalized := make(chan error, 1)
+	go func() {
+		_, _, err := intruder.CreateOrderCert(t.Context(), order.FinalizeURL, intruderCSR, true)
+		finalized <- err
+	}()
+
+	// The intruder's finalize is parked reading the order.
+	gate := <-storage.parked
+	release := sync.OnceFunc(func() { close(gate) })
+	defer release()
+
+	polled, err := owner.GetOrder(t.Context(), order.URI)
+	if err != nil {
+		t.Errorf("GetOrder() error = %v", err)
+	} else if polled.Status != acme.StatusReady {
+		t.Errorf("order status during foreign finalize = %q, want %q", polled.Status, acme.StatusReady)
+	}
+
+	if _, _, err := owner.CreateOrderCert(t.Context(), order.FinalizeURL, newCSR(t), true); err != nil {
+		t.Errorf("owner CreateOrderCert() error = %v, want success", err)
+	}
+
+	release()
+	var ae *acme.Error
+	if err := <-finalized; !errors.As(err, &ae) || ae.ProblemType != "urn:ietf:params:acme:error:unauthorized" {
+		t.Errorf("intruder CreateOrderCert() error = %v, want unauthorized", err)
+	}
+}
+
+// challengeValidRacedStorage simulates another CA instance completing the
+// challenge between our processing transition and the terminal write: the
+// stored record advances to valid, and our write reports ErrStatusMismatch.
+type challengeValidRacedStorage struct {
+	nanoca.Storage
+}
+
+func (s challengeValidRacedStorage) SetChallengeValid(ctx context.Context, id, reservationToken string, validated time.Time, attestation []byte) error {
+	if err := s.Storage.SetChallengeValid(ctx, id, reservationToken, validated, attestation); err != nil {
+		return err
+	}
+	return fmt.Errorf("challenge status is valid, not processing: %w", nanoca.ErrStatusMismatch)
+}
+
+// Losing the terminal write to a concurrent validation is the same
+// client-state condition the SetChallengeProcessing path reports with the
+// challenge's current state; a 500 invites the client to retry a challenge
+// that has already succeeded.
+func TestChallengeValidStatusMismatchReportsState(t *testing.T) {
+	t.Parallel()
+
+	storage := challengeValidRacedStorage{Storage: newTestStorage(t)}
+	ts := newStorageTestServer(t, storage, stubIssuer{})
+
+	client := newACMEClient(t, ts)
+	_, chal := pendingChallenge(t, client, "raced-device")
+
+	err := submitAttObj(t, client, chal, nullAttObj(t))
+	var ae *acme.Error
+	if errors.As(err, &ae) && ae.StatusCode >= http.StatusInternalServerError {
+		t.Errorf("raced challenge POST status = %d, want non-5xx", ae.StatusCode)
+	}
+}
+
+// orderStatusMismatchStorage rejects every guarded status transition, as
+// when another request has already settled the order.
+type orderStatusMismatchStorage struct {
+	nanoca.Storage
+}
+
+func (s orderStatusMismatchStorage) SetOrderStatus(_ context.Context, _, from, _ string) error {
+	return fmt.Errorf("order status is valid, not %s: %w", from, nanoca.ErrStatusMismatch)
+}
+
+// updateOrderStatus tolerates losing the transition race, but it must not
+// log a status change that never happened.
+func TestOrderStatusChangeLoggedOnlyOnTransition(t *testing.T) {
+	t.Parallel()
+
+	var logs syncBuffer
+	logger := slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	ts, _ := newTestServer(t, testServerConfig{logger: logger, issuer: stubIssuer{}, storage: orderStatusMismatchStorage{Storage: newTestStorage(t)}})
+
+	client := newACMEClient(t, ts)
+	_, chal := pendingChallenge(t, client, "settled-device")
+	if err := submitAttObj(t, client, chal, nullAttObj(t)); err != nil {
+		t.Fatalf("failed to satisfy challenge: %v", err)
+	}
+
+	if strings.Contains(logs.String(), "Order status changed") {
+		t.Errorf("logs claim an order status change that was rejected:\n%s", logs.String())
+	}
+}
+
+// A finalize whose lease lapses while it is still signing must not persist
+// its certificate over the reclaiming retry's: the stored certificate has to
+// answer the CSR of the finalize that holds the reservation.
+func TestFinalizeZombieCannotPersistStaleCSR(t *testing.T) {
+	t.Parallel()
+
+	issuer := &gatedIssuer{entered: make(chan struct{}), release: make(chan struct{})}
+	ts := newShortLeaseTestServer(t, newTestStorage(t), issuer)
+
+	client := newACMEClient(t, ts)
+	order, chal := pendingChallenge(t, client, "zombie-device")
+	if err := submitAttObj(t, client, chal, nullAttObj(t)); err != nil {
+		t.Fatalf("failed to satisfy challenge: %v", err)
+	}
+
+	zombieCSR := newCSR(t)
+	zombieDone := make(chan error, 1)
+	go func() {
+		_, _, err := client.CreateOrderCert(t.Context(), order.FinalizeURL, zombieCSR, true)
+		zombieDone <- err
+	}()
+	<-issuer.entered
+
+	// The zombie is parked inside IssueCertificate; retry with a fresh CSR
+	// until its lease lapses and the reservation is reclaimed.
+	retryCSR := newCSR(t)
+	var chain [][]byte
+	var err error
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		chain, _, err = client.CreateOrderCert(t.Context(), order.FinalizeURL, retryCSR, true)
+		if err == nil || time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if err != nil {
+		t.Fatalf("reclaiming CreateOrderCert() error = %v", err)
+	}
+
+	close(issuer.release)
+	if err := <-zombieDone; err == nil {
+		t.Error("zombie CreateOrderCert() error = nil, want failure after reclaim")
+	}
+
+	csr, err := x509.ParseCertificateRequest(retryCSR)
+	if err != nil {
+		t.Fatalf("failed to parse CSR: %v", err)
+	}
+	cert, err := x509.ParseCertificate(chain[0])
+	if err != nil {
+		t.Fatalf("failed to parse certificate: %v", err)
+	}
+	key, ok := cert.PublicKey.(*ecdsa.PublicKey)
+	if !ok {
+		t.Fatalf("certificate public key type = %T, want *ecdsa.PublicKey", cert.PublicKey)
+	}
+	if !key.Equal(csr.PublicKey) {
+		t.Error("stored certificate does not answer the reservation holder's CSR")
+	}
+}
+
+// An order abandoned mid-finalize by a dead CA instance sits processing in
+// storage; once the reservation lapses, polls must report ready — telling an
+// RFC 8555 Section 7.1.6 client to re-submit — and the re-submitted finalize
+// must reclaim and complete.
+func TestOrderRecoversFromAbandonedReservation(t *testing.T) {
+	t.Parallel()
+
+	storage := newTestStorage(t)
+	ts := newShortLeaseTestServer(t, storage, selfSignedIssuer{})
+
+	client := newACMEClient(t, ts)
+	order, chal := pendingChallenge(t, client, "abandoned-device")
+	if err := submitAttObj(t, client, chal, nullAttObj(t)); err != nil {
+		t.Fatalf("failed to satisfy challenge: %v", err)
+	}
+
+	orderID := path.Base(order.URI)
+	if err := storage.ReserveOrderFinalize(t.Context(), orderID, "dead-instance", time.Minute); err != nil {
+		t.Fatalf("ReserveOrderFinalize() error = %v", err)
+	}
+
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		polled, err := client.GetOrder(t.Context(), order.URI)
+		if err != nil {
+			t.Fatalf("GetOrder() error = %v", err)
+		}
+		if polled.Status == acme.StatusReady {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("order status = %q, want %q after reservation lapse", polled.Status, acme.StatusReady)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if _, _, err := client.CreateOrderCert(t.Context(), order.FinalizeURL, newCSR(t), true); err != nil {
+		t.Errorf("CreateOrderCert() after abandoned reservation error = %v, want success", err)
+	}
+}
+
+// authzDemotingStorage, once armed, reports every authorization as pending,
+// so a finalize observes a ready order whose authorization no longer reads
+// valid — the state a stale authorization write leaves behind.
+type authzDemotingStorage struct {
+	nanoca.Storage
+	mu    sync.Mutex
+	armed bool
+}
+
+func (s *authzDemotingStorage) arm() {
+	s.mu.Lock()
+	s.armed = true
+	s.mu.Unlock()
+}
+
+func (s *authzDemotingStorage) GetAuthorization(ctx context.Context, id string) (*nanoca.Authorization, error) {
+	authz, err := s.Storage.GetAuthorization(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	s.mu.Lock()
+	armed := s.armed
+	s.mu.Unlock()
+	if armed {
+		authz.Status = nanoca.AuthzStatusPending
+	}
+	return authz, nil
+}
+
+// The order only reached ready through a valid authorization, so a
+// finalize that cannot re-derive the attested identity must abort rather
+// than mint a certificate with the permanent-identifier/hardware-module
+// SANs silently stripped.
+func TestFinalizeRefusesOrderWithoutValidAuthz(t *testing.T) {
+	t.Parallel()
+
+	storage := &authzDemotingStorage{Storage: newTestStorage(t)}
+	ts := newStorageTestServer(t, storage, nil)
+
+	client := newACMEClient(t, ts)
+	order, chal := pendingChallenge(t, client, "demoted-device")
+	if err := submitAttObj(t, client, chal, nullAttObj(t)); err != nil {
+		t.Fatalf("failed to satisfy challenge: %v", err)
+	}
+
+	storage.arm()
+	chain, _, err := client.CreateOrderCert(t.Context(), order.FinalizeURL, newCSR(t), true)
+	if err != nil {
+		return
+	}
+
+	cert, err := x509.ParseCertificate(chain[0])
+	if err != nil {
+		t.Fatalf("failed to parse certificate: %v", err)
+	}
+	sanOID := asn1.ObjectIdentifier{2, 5, 29, 17}
+	for _, ext := range cert.Extensions {
+		if ext.Id.Equal(sanOID) {
+			return
+		}
+	}
+	t.Error("finalize issued a certificate without the attested identifiers")
+}
+
+// The attestation blob belongs to the challenge record: finalize re-reads it
+// through GetChallenge and responses scrub it, so nothing ever reads a copy
+// embedded in the authorization. Persisting one there duplicates a
+// multi-kilobyte CBOR object into every settled authorization and pays its
+// (de)serialization on every authz poll, order recompute, and finalize.
+func TestSettledAuthorizationOmitsAttestation(t *testing.T) {
+	t.Parallel()
+
+	storage := newTestStorage(t)
+	ts := newStorageTestServer(t, storage, nil)
+
+	client := newACMEClient(t, ts)
+	order, chal := pendingChallenge(t, client, "embedded-blob-device")
+	if err := submitAttObj(t, client, chal, nullAttObj(t)); err != nil {
+		t.Fatalf("failed to satisfy challenge: %v", err)
+	}
+
+	authz, err := storage.GetAuthorization(t.Context(), path.Base(order.AuthzURLs[0]))
+	if err != nil {
+		t.Fatalf("GetAuthorization() error = %v", err)
+	}
+	if authz.Status != nanoca.AuthzStatusValid {
+		t.Fatalf("authorization status = %q, want %q", authz.Status, nanoca.AuthzStatusValid)
+	}
+	for _, challenge := range authz.Challenges {
+		if len(challenge.Attestation) > 0 {
+			t.Errorf("settled authorization embeds a %d-byte attestation for challenge %s", len(challenge.Attestation), challenge.ID)
+		}
+	}
+}
+
+// completeOrderRacedStorage simulates a zombie finalize whose lease lapsed
+// mid-issuance: by the time its fenced completion lands, a retry has
+// reclaimed the reservation, so the write reports ErrReserved.
+type completeOrderRacedStorage struct {
+	nanoca.Storage
+}
+
+func (s completeOrderRacedStorage) CompleteOrder(context.Context, *nanoca.Order, *nanoca.Certificate, string) error {
+	return fmt.Errorf("order reservation is held by another token: %w", nanoca.ErrReserved)
+}
+
+// Losing the finalize reservation to a reclaiming retry is the same
+// client-state condition the reserve path answers with 403 orderNotReady
+// and the challenge path answers with the current state; a 500 invites the
+// client to retry a finalize that has already been superseded.
+func TestFinalizeCompletionRaceNonRetriable(t *testing.T) {
+	t.Parallel()
+
+	storage := completeOrderRacedStorage{Storage: newTestStorage(t)}
+	ts := newStorageTestServer(t, storage, selfSignedIssuer{})
+
+	client := newACMEClient(t, ts)
+	order, chal := pendingChallenge(t, client, "reclaimed-device")
+	if err := submitAttObj(t, client, chal, nullAttObj(t)); err != nil {
+		t.Fatalf("failed to satisfy challenge: %v", err)
+	}
+
+	_, _, err := client.CreateOrderCert(t.Context(), order.FinalizeURL, newCSR(t), true)
+	var ae *acme.Error
+	if !errors.As(err, &ae) {
+		t.Fatalf("CreateOrderCert() error = %v, want *acme.Error", err)
+	}
+	if ae.StatusCode >= http.StatusInternalServerError {
+		t.Errorf("finalize after lost completion race status = %d, want non-5xx", ae.StatusCode)
+	}
+}

--- a/handlers_verifier_test.go
+++ b/handlers_verifier_test.go
@@ -5,10 +5,10 @@ import (
 	"encoding/base64"
 	"errors"
 	"net/http"
+	"sync"
 	"testing"
 
 	"github.com/brandonweeks/nanoca"
-	nullauthorizer "github.com/brandonweeks/nanoca/authorizers/null"
 	"github.com/fxamacker/cbor/v2"
 	"golang.org/x/crypto/acme"
 )
@@ -21,10 +21,137 @@ func (erroringVerifier) Verify(context.Context, nanoca.AttestationStatement, []b
 	return nil, errors.New("attestation invalid")
 }
 
+type nilDeviceInfoVerifier struct{}
+
+func (nilDeviceInfoVerifier) Format() string { return "nildev" }
+
+func (nilDeviceInfoVerifier) Verify(context.Context, nanoca.AttestationStatement, []byte) (*nanoca.DeviceInfo, error) {
+	return nil, nil
+}
+
+// The AttestationVerifier contract does not promise a non-nil DeviceInfo. An
+// order whose only identity source is a verifier that yields none can never
+// finalize — re-verification deterministically re-yields nothing — so the
+// failure must surface as a terminal problem: a 5xx tells the client to
+// retry forever (see the RetryBackoff comment in handlers_flow_test.go).
+// Refusing the identity-less validation at challenge time is also correct.
+func TestFinalizeNilDeviceInfoTerminal(t *testing.T) {
+	t.Parallel()
+
+	ts, _ := newTestServer(t, testServerConfig{verifiers: []nanoca.AttestationVerifier{nilDeviceInfoVerifier{}}})
+	client := newACMEClient(t, ts)
+
+	order, chal := pendingChallenge(t, client, "nil-identity-device")
+	if err := submitAttObj(t, client, chal, attObjFor(t, "nildev")); err != nil {
+		return
+	}
+
+	_, _, err := client.CreateOrderCert(t.Context(), order.FinalizeURL, newCSR(t), true)
+	var ae *acme.Error
+	if !errors.As(err, &ae) {
+		t.Fatalf("CreateOrderCert() error = %v, want *acme.Error", err)
+	}
+	if ae.StatusCode >= http.StatusInternalServerError {
+		t.Errorf("finalize with no attested identity status = %d, want terminal non-5xx", ae.StatusCode)
+	}
+}
+
+// A verifier that returns no identity leaves finalize nothing to build the
+// certificate's SANs from, so the challenge must fail rather than settle
+// valid and wedge the order.
+func TestChallengeNilDeviceInfoRejected(t *testing.T) {
+	t.Parallel()
+
+	ts, _ := newTestServer(t, testServerConfig{verifiers: []nanoca.AttestationVerifier{nilDeviceInfoVerifier{}}})
+	client := newACMEClient(t, ts)
+
+	_, chal := pendingChallenge(t, client, "nil-identity-rejected-device")
+
+	err := submitAttObj(t, client, chal, attObjFor(t, "nildev"))
+	if err == nil {
+		t.Fatal("Accept() error = nil, want rejection of identity-less attestation")
+	}
+
+	var ae *acme.Error
+	if errors.As(err, &ae) && ae.StatusCode >= http.StatusInternalServerError {
+		t.Errorf("challenge POST status = %d, want non-5xx rejection", ae.StatusCode)
+	}
+}
+
+type captureVerifier struct {
+	mu    sync.Mutex
+	stmts []nanoca.AttestationStatement
+}
+
+func (v *captureVerifier) Format() string { return "capture" }
+
+func (v *captureVerifier) Verify(_ context.Context, stmt nanoca.AttestationStatement, _ []byte) (*nanoca.DeviceInfo, error) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.stmts = append(v.stmts, stmt)
+	return &nanoca.DeviceInfo{
+		PermanentIdentifier: &nanoca.PermanentIdentifier{Identifier: "captured-device"},
+	}, nil
+}
+
+// Finalize re-verifies the stored statement, so the verifier must receive
+// what it verified at challenge time. The storage round-trip currently
+// rewrites []byte values (an apple x5c chain) into base64 strings and the
+// handler injects a "fmt" entry — either breaks a verifier that checks its
+// input strictly, as verifiers/apple does.
+func TestFinalizeReverifiesOriginalStatement(t *testing.T) {
+	t.Parallel()
+
+	verifier := &captureVerifier{}
+	ts, _ := newTestServer(t, testServerConfig{verifiers: []nanoca.AttestationVerifier{verifier}})
+	client := newACMEClient(t, ts)
+
+	order, chal := pendingChallenge(t, client, "capture-device")
+	attObj, err := cbor.Marshal(map[string]any{
+		"fmt":     "capture",
+		"attStmt": map[string]any{"x5c": []any{[]byte("leaf certificate der")}},
+	})
+	if err != nil {
+		t.Fatalf("failed to marshal attestation: %v", err)
+	}
+	if err := submitAttObj(t, client, chal, base64.RawURLEncoding.EncodeToString(attObj)); err != nil {
+		t.Fatalf("failed to satisfy challenge: %v", err)
+	}
+	if _, _, err := client.CreateOrderCert(t.Context(), order.FinalizeURL, newCSR(t), true); err != nil {
+		t.Fatalf("CreateOrderCert() error = %v", err)
+	}
+
+	verifier.mu.Lock()
+	stmts := verifier.stmts
+	verifier.mu.Unlock()
+	if len(stmts) != 2 {
+		t.Fatalf("Verify calls = %d, want 2 (challenge, finalize)", len(stmts))
+	}
+	x5c, ok := stmts[0].AttStmt["x5c"].([]any)
+	if !ok || len(x5c) != 1 {
+		t.Fatalf("challenge-time x5c = %#v, want one-element []any", stmts[0].AttStmt["x5c"])
+	}
+	if _, ok := x5c[0].([]byte); !ok {
+		t.Fatalf("challenge-time x5c[0] type = %T, want []byte", x5c[0])
+	}
+
+	finalize := stmts[1].AttStmt
+	if _, ok := finalize["fmt"]; ok {
+		t.Error(`finalize-time attStmt contains an injected "fmt" key`)
+	}
+	x5c, ok = finalize["x5c"].([]any)
+	if !ok || len(x5c) != 1 {
+		t.Fatalf("finalize-time x5c = %#v, want one-element []any", finalize["x5c"])
+	}
+	if _, ok := x5c[0].([]byte); !ok {
+		t.Errorf("finalize-time x5c[0] type = %T, want []byte", x5c[0])
+	}
+}
+
 func TestChallengeVerifierFailure(t *testing.T) {
 	t.Parallel()
 
-	ts, _ := newTestServer(t, nullauthorizer.New(), nil, nil, erroringVerifier{})
+	ts, _ := newTestServer(t, testServerConfig{verifiers: []nanoca.AttestationVerifier{erroringVerifier{}}})
 	client := newACMEClient(t, ts)
 
 	order, chal := pendingChallenge(t, client, "failing-device")
@@ -43,39 +170,5 @@ func TestChallengeVerifierFailure(t *testing.T) {
 	}
 	if authz.Status != acme.StatusInvalid {
 		t.Errorf("authorization status = %q, want invalid", authz.Status)
-	}
-}
-
-type nilDeviceInfoVerifier struct{}
-
-func (nilDeviceInfoVerifier) Format() string { return "nildev" }
-
-func (nilDeviceInfoVerifier) Verify(context.Context, nanoca.AttestationStatement, []byte) (*nanoca.DeviceInfo, error) {
-	return nil, nil
-}
-
-// A verifier that returns no identity leaves finalize nothing to build the
-// certificate's SANs from, so the challenge must fail rather than settle
-// valid and wedge the order.
-func TestChallengeNilDeviceInfoRejected(t *testing.T) {
-	t.Parallel()
-
-	ts, _ := newTestServer(t, nullauthorizer.New(), nil, nil, nilDeviceInfoVerifier{})
-	client := newACMEClient(t, ts)
-
-	_, chal := pendingChallenge(t, client, "nil-identity-device")
-
-	attObj, err := cbor.Marshal(map[string]any{"fmt": "nildev", "attStmt": map[string]any{}})
-	if err != nil {
-		t.Fatalf("failed to marshal attestation: %v", err)
-	}
-	err = submitAttObj(t, client, chal, base64.RawURLEncoding.EncodeToString(attObj))
-	if err == nil {
-		t.Fatal("Accept() error = nil, want rejection of identity-less attestation")
-	}
-
-	var ae *acme.Error
-	if errors.As(err, &ae) && ae.StatusCode >= http.StatusInternalServerError {
-		t.Errorf("challenge POST status = %d, want non-5xx rejection", ae.StatusCode)
 	}
 }

--- a/integration_test.go
+++ b/integration_test.go
@@ -207,10 +207,23 @@ func TestDeviceAttestationFlow(t *testing.T) {
 
 func setupTestServerWithAttestation(t *testing.T, authorizer nanoca.Authorizer) (*httptest.Server, *nanoca.CA) {
 	t.Helper()
-	return newTestServer(t, authorizer, nil, nil)
+	return newTestServer(t, testServerConfig{authorizer: authorizer})
 }
 
-func newTestServer(t *testing.T, authorizer nanoca.Authorizer, issuerOverride nanoca.CertificateIssuer, observerOverride nanoca.IssuanceObserver, extraVerifiers ...nanoca.AttestationVerifier) (*httptest.Server, *nanoca.CA) {
+// testServerConfig overrides newTestServer's defaults; a zero field keeps
+// the discarded logs, null authorizer, in-process issuer, mock observer,
+// and in-memory storage.
+type testServerConfig struct {
+	logger     *slog.Logger
+	authorizer nanoca.Authorizer
+	issuer     nanoca.CertificateIssuer
+	observer   nanoca.IssuanceObserver
+	storage    nanoca.Storage
+	opts       []nanoca.Option
+	verifiers  []nanoca.AttestationVerifier
+}
+
+func newTestServer(t *testing.T, cfg testServerConfig) (*httptest.Server, *nanoca.CA) {
 	t.Helper()
 
 	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -265,12 +278,26 @@ func newTestServer(t *testing.T, authorizer nanoca.Authorizer, issuerOverride na
 		t.Fatalf("Failed to parse intermediate CA certificate: %v", err)
 	}
 
-	storage, err := store.New(store.Options{InMemory: true})
-	if err != nil {
-		t.Fatalf("Failed to create in-memory storage: %v", err)
+	logger := cfg.logger
+	if logger == nil {
+		logger = slog.New(slog.DiscardHandler)
 	}
 
-	issuer := issuerOverride
+	authorizer := cfg.authorizer
+	if authorizer == nil {
+		authorizer = nullauthorizer.New()
+	}
+
+	storage := cfg.storage
+	if storage == nil {
+		s, err := store.New(store.Options{InMemory: true})
+		if err != nil {
+			t.Fatalf("Failed to create in-memory storage: %v", err)
+		}
+		storage = s
+	}
+
+	issuer := cfg.issuer
 	if issuer == nil {
 		inproc, err := inprocess.New(intermKey, intermCert, caCert)
 		if err != nil {
@@ -279,18 +306,19 @@ func newTestServer(t *testing.T, authorizer nanoca.Authorizer, issuerOverride na
 		issuer = inproc
 	}
 
-	observer := observerOverride
+	observer := cfg.observer
 	if observer == nil {
 		observer = &mockIssuanceObserver{}
 	}
 
 	opts := []nanoca.Option{nanoca.WithObserver(observer), nanoca.WithVerifier(null.New())}
-	for _, v := range extraVerifiers {
+	for _, v := range cfg.verifiers {
 		opts = append(opts, nanoca.WithVerifier(v))
 	}
+	opts = append(opts, cfg.opts...)
 
 	ca, err := nanoca.New(
-		slog.New(slog.DiscardHandler),
+		logger,
 		issuer,
 		authorizer,
 		storage,

--- a/storage.go
+++ b/storage.go
@@ -2,7 +2,42 @@ package nanoca
 
 import (
 	"context"
+	"errors"
 	"time"
+)
+
+// Sentinel errors that Storage implementations must return (possibly wrapped)
+// so handlers can distinguish expected conditions — a missing or expired
+// object, a duplicate account key, a reservation held elsewhere — from a
+// backend failure. Operations that fail for any other reason are treated as
+// internal server errors.
+//
+//   - Get*, Update*, Settle*, Reserve*, and SetChallenge* must return
+//     ErrNotFound when the object does not exist.
+//   - ConsumeNonce must return ErrNotFound for an unknown or already
+//     consumed nonce, and ErrNonceExpired after consuming an expired one.
+//   - CreateAccount must return ErrAccountExists, atomically with the
+//     write, if an account already exists with the same key thumbprint.
+//   - SetOrderStatus, SettleAuthorization, and the reserve/fenced methods
+//     below must return ErrStatusMismatch, atomically with the write, when
+//     the record is not in the expected preceding status.
+//   - Reserve* must return ErrReserved, atomically with the write, while
+//     an unexpired reservation is held; the fenced writes (CompleteOrder,
+//     ReleaseOrderFinalize, ReleaseChallengeValidation, SetChallengeValid,
+//     SetChallengeInvalid) must return ErrReserved when the presented token
+//     does not match the stored reservation. Successful fenced writes clear
+//     the reservation.
+//
+// Reservation leases are judged by comparing the stored ReservedAt against
+// the caller-supplied duration with the backend's clock, so a shared
+// backend assumes loosely synchronized CA hosts: clock skew shifts the
+// effective lease by the skew.
+var (
+	ErrNotFound       = errors.New("not found")
+	ErrNonceExpired   = errors.New("nonce expired")
+	ErrAccountExists  = errors.New("account already exists")
+	ErrStatusMismatch = errors.New("status mismatch")
+	ErrReserved       = errors.New("reservation held")
 )
 
 type Storage interface {
@@ -11,25 +46,69 @@ type Storage interface {
 
 	CreateAccount(ctx context.Context, account *Account) error
 	GetAccount(ctx context.Context, id string) (*Account, error)
+	// GetAccountByKey looks up an account by Account.KeyThumbprint: the
+	// unpadded base64url encoding of the SHA-256 JWK thumbprint (RFC 7638)
+	// of the account key.
 	GetAccountByKey(ctx context.Context, keyThumbprint string) (*Account, error)
 	UpdateAccount(ctx context.Context, account *Account) error
 
 	CreateOrder(ctx context.Context, order *Order) error
 	GetOrder(ctx context.Context, id string) (*Order, error)
-	UpdateOrder(ctx context.Context, order *Order) error
+	// SetOrderStatus transitions an order from one status to the next only
+	// if it is still in the expected preceding status, so a stale caller
+	// cannot overwrite a transition that has already happened.
+	SetOrderStatus(ctx context.Context, id, from, to string) error
+	// ReserveOrderFinalize takes the exclusive right to finalize an order:
+	// atomically, it transitions a ready order to processing — or reclaims
+	// a processing order whose reservation is older than lease — recording
+	// token and the reservation time. It returns ErrReserved while an
+	// unexpired reservation is held and ErrStatusMismatch for any other
+	// status. The reservation is consumed by CompleteOrder or surrendered
+	// by ReleaseOrderFinalize; it holds across CA processes sharing this
+	// storage.
+	ReserveOrderFinalize(ctx context.Context, id, token string, lease time.Duration) error
+	// ReleaseOrderFinalize surrenders a finalize reservation, transitioning
+	// the order from processing to `to` — ready, so a retry can finalize
+	// again, or invalid, for a terminal failure — and clearing the
+	// reservation. The write is fenced by token.
+	ReleaseOrderFinalize(ctx context.Context, id, token, to string) error
 	GetOrdersByAccount(ctx context.Context, accountID string) ([]*Order, error)
 
 	CreateAuthorization(ctx context.Context, authz *Authorization) error
 	GetAuthorization(ctx context.Context, id string) (*Authorization, error)
-	UpdateAuthorization(ctx context.Context, authz *Authorization) error
+	// SettleAuthorization transitions a pending authorization to
+	// authz.Status — valid or invalid — writing the full record so the
+	// refreshed embedded challenge copies land with the transition. It
+	// returns ErrStatusMismatch, atomically with the write, when the stored
+	// authorization is no longer pending, so a recompute from stale reads
+	// cannot overwrite a settlement another request has since written.
+	SettleAuthorization(ctx context.Context, authz *Authorization) error
 
 	CreateChallenge(ctx context.Context, challenge *Challenge) error
 	GetChallenge(ctx context.Context, id string) (*Challenge, error)
-	SetChallengeProcessing(ctx context.Context, id string) error
-	SetChallengeValid(ctx context.Context, id string, validated time.Time, attestation map[string]any) error
-	SetChallengeInvalid(ctx context.Context, id string, validated time.Time, problem *Problem) error
+	// ReserveChallengeValidation takes the exclusive right to validate a
+	// challenge, with the same contract as ReserveOrderFinalize: pending to
+	// processing, or reclaim of an expired reservation.
+	ReserveChallengeValidation(ctx context.Context, id, reservationToken string, lease time.Duration) error
+	// ReleaseChallengeValidation surrenders a validation reservation,
+	// returning the challenge from processing to pending so a retry can
+	// validate again after a transient failure. The write is fenced by
+	// reservationToken.
+	ReleaseChallengeValidation(ctx context.Context, id, reservationToken string) error
+	// SetChallengeValid stores the raw CBOR attestation object beside the
+	// status; it is opaque to storage and re-verified byte-for-byte at
+	// finalize. The write is fenced by reservationToken and clears the
+	// reservation.
+	SetChallengeValid(ctx context.Context, id, reservationToken string, validated time.Time, attestation []byte) error
+	SetChallengeInvalid(ctx context.Context, id, reservationToken string, validated time.Time, problem *Problem) error
 
-	CreateCertificate(ctx context.Context, cert *Certificate) error
+	// CompleteOrder atomically stores the certificate under Certificate.ID
+	// — the identifier GetCertificate looks up — and transitions the order
+	// from processing to valid, clearing its reservation; the write is
+	// fenced by token, so a finalize whose reservation was reclaimed cannot
+	// persist a certificate for a stale CSR. On error neither write is
+	// persisted, so a stored certificate always belongs to a valid order.
+	CompleteOrder(ctx context.Context, order *Order, cert *Certificate, token string) error
 	GetCertificate(ctx context.Context, id string) (*Certificate, error)
 
 	Close() error

--- a/storage/badger/errors_test.go
+++ b/storage/badger/errors_test.go
@@ -43,15 +43,31 @@ func TestNotFoundErrors(t *testing.T) {
 		{"GetChallenge", func() error { _, err := s.GetChallenge(ctx, "ghost"); return err }},
 		{"GetCertificate", func() error { _, err := s.GetCertificate(ctx, "ghost"); return err }},
 		{"UpdateAccount", func() error { return s.UpdateAccount(ctx, &nanoca.Account{ID: "ghost"}) }},
-		{"UpdateOrder", func() error { return s.UpdateOrder(ctx, &nanoca.Order{ID: "ghost"}) }},
-		{"UpdateAuthz", func() error { return s.UpdateAuthorization(ctx, &nanoca.Authorization{ID: "ghost"}) }},
-		{"SetProcessing", func() error { return s.SetChallengeProcessing(ctx, "ghost") }},
+		{"SettleAuthz", func() error { return s.SettleAuthorization(ctx, &nanoca.Authorization{ID: "ghost"}) }},
+		{"ReserveChallengeValidation", func() error {
+			return s.ReserveChallengeValidation(ctx, "ghost", "token", time.Minute)
+		}},
+		{"ReleaseChallengeValidation", func() error {
+			return s.ReleaseChallengeValidation(ctx, "ghost", "token")
+		}},
+		{"ReserveOrderFinalize", func() error {
+			return s.ReserveOrderFinalize(ctx, "ghost", "token", time.Minute)
+		}},
+		{"ReleaseOrderFinalize", func() error {
+			return s.ReleaseOrderFinalize(ctx, "ghost", "token", nanoca.OrderStatusReady)
+		}},
+		{"SetOrderStatus", func() error {
+			return s.SetOrderStatus(ctx, "ghost", nanoca.OrderStatusPending, nanoca.OrderStatusReady)
+		}},
+		{"CompleteOrder", func() error {
+			return s.CompleteOrder(ctx, &nanoca.Order{ID: "ghost"}, &nanoca.Certificate{ID: "ghost"}, "token")
+		}},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := tt.fn(); err == nil {
-				t.Errorf("%s(missing) error = nil, want not-found error", tt.name)
+			if err := tt.fn(); !errors.Is(err, nanoca.ErrNotFound) {
+				t.Errorf("%s(missing) error = %v, want ErrNotFound", tt.name, err)
 			}
 		})
 	}
@@ -63,8 +79,8 @@ func TestConsumeNonceErrors(t *testing.T) {
 	s := newTestStore(t)
 	ctx := t.Context()
 
-	if _, err := s.ConsumeNonce(ctx, "ghost", time.Hour); !errors.Is(err, nanoca.ErrNonceNotFound) {
-		t.Errorf("ConsumeNonce(missing) error = %v, want ErrNonceNotFound", err)
+	if _, err := s.ConsumeNonce(ctx, "ghost", time.Hour); !errors.Is(err, nanoca.ErrNotFound) {
+		t.Errorf("ConsumeNonce(missing) error = %v, want ErrNotFound", err)
 	}
 
 	if err := s.CreateNonce(ctx, &nanoca.Nonce{Value: "n1", CreatedAt: time.Now()}); err != nil {
@@ -76,8 +92,8 @@ func TestConsumeNonceErrors(t *testing.T) {
 	}
 	// Consuming an expired nonce must still remove it, or expired nonces
 	// accumulate forever (nonce keys carry no TTL).
-	if _, err := s.ConsumeNonce(ctx, "n1", -time.Second); !errors.Is(err, nanoca.ErrNonceNotFound) {
-		t.Errorf("ConsumeNonce(expired, again) error = %v, want ErrNonceNotFound", err)
+	if _, err := s.ConsumeNonce(ctx, "n1", -time.Second); !errors.Is(err, nanoca.ErrNotFound) {
+		t.Errorf("ConsumeNonce(expired, again) error = %v, want ErrNotFound", err)
 	}
 }
 
@@ -90,8 +106,36 @@ func TestChallengeStatusMismatch(t *testing.T) {
 	if err := s.CreateChallenge(ctx, &nanoca.Challenge{ID: "c1", Status: nanoca.ChallengeStatusValid}); err != nil {
 		t.Fatalf("CreateChallenge() error = %v", err)
 	}
-	if err := s.SetChallengeProcessing(ctx, "c1"); err == nil {
-		t.Error("SetChallengeProcessing(valid challenge) error = nil, want status mismatch")
+	if err := s.ReserveChallengeValidation(ctx, "c1", "token", time.Minute); !errors.Is(err, nanoca.ErrStatusMismatch) {
+		t.Errorf("ReserveChallengeValidation(valid challenge) error = %v, want ErrStatusMismatch", err)
+	}
+}
+
+func TestSetOrderStatus(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStore(t)
+	ctx := t.Context()
+
+	if err := s.CreateOrder(ctx, &nanoca.Order{ID: "o1", Status: nanoca.OrderStatusPending}); err != nil {
+		t.Fatalf("CreateOrder() error = %v", err)
+	}
+	if err := s.SetOrderStatus(ctx, "o1", nanoca.OrderStatusPending, nanoca.OrderStatusReady); err != nil {
+		t.Fatalf("SetOrderStatus() error = %v", err)
+	}
+
+	order, err := s.GetOrder(ctx, "o1")
+	if err != nil {
+		t.Fatalf("GetOrder() error = %v", err)
+	}
+	if order.Status != nanoca.OrderStatusReady {
+		t.Errorf("order status = %q, want %q", order.Status, nanoca.OrderStatusReady)
+	}
+
+	// The guard is what keeps a stale caller from redoing a transition
+	// another request already made.
+	if err := s.SetOrderStatus(ctx, "o1", nanoca.OrderStatusPending, nanoca.OrderStatusReady); !errors.Is(err, nanoca.ErrStatusMismatch) {
+		t.Errorf("SetOrderStatus(ready) error = %v, want ErrStatusMismatch", err)
 	}
 }
 
@@ -101,10 +145,8 @@ func TestGetCertificateBadRaw(t *testing.T) {
 	s := newTestStore(t)
 	ctx := t.Context()
 
-	if err := s.CreateCertificate(ctx, &nanoca.Certificate{SerialNumber: "s1", Raw: []byte("not-a-cert")}); err != nil {
-		t.Fatalf("CreateCertificate() error = %v", err)
-	}
-	if _, err := s.GetCertificate(ctx, "s1"); err == nil {
+	storeCertificate(t, s, &nanoca.Certificate{ID: "o1", Raw: []byte("not-a-cert")})
+	if _, err := s.GetCertificate(ctx, "o1"); err == nil {
 		t.Error("GetCertificate(bad raw) error = nil, want parse error")
 	}
 }

--- a/storage/badger/storage.go
+++ b/storage/badger/storage.go
@@ -89,35 +89,114 @@ func (s *Storage) CreateNonce(_ context.Context, nonce *nanoca.Nonce) error {
 	})
 }
 
+// update retries fn when badger's optimistic concurrency detects a
+// conflicting commit; our write transactions are small read-then-write ops
+// for which a retry is always safe.
+func (s *Storage) update(fn func(txn *badger.Txn) error) error {
+	for {
+		err := s.db.Update(fn)
+		if !errors.Is(err, badger.ErrConflict) {
+			return err
+		}
+	}
+}
+
+// getValue loads a key's value, mapping a missing key to nanoca.ErrNotFound.
+func getValue(txn *badger.Txn, key []byte, resource string) ([]byte, error) {
+	item, err := txn.Get(key)
+	if err != nil {
+		if errors.Is(err, badger.ErrKeyNotFound) {
+			return nil, nanoca.ErrNotFound
+		}
+		return nil, fmt.Errorf("failed to get %s: %w", resource, err)
+	}
+	return item.ValueCopy(nil)
+}
+
+func getJSON(txn *badger.Txn, key []byte, resource string, dst any) error {
+	data, err := getValue(txn, key, resource)
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(data, dst); err != nil {
+		return fmt.Errorf("failed to unmarshal %s: %w", resource, err)
+	}
+	return nil
+}
+
+func setJSON(txn *badger.Txn, key []byte, resource string, v any) error {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Errorf("failed to marshal %s: %w", resource, err)
+	}
+	return txn.Set(key, data)
+}
+
+// reservedRecord points at the status and reservation fields the
+// reserve/fence state machine manipulates, so orders and challenges share
+// one implementation of its transitions.
+type reservedRecord struct {
+	status      *string
+	reservation **nanoca.Reservation
+	resource    string
+	processing  string
+}
+
+func orderRecord(o *nanoca.Order) reservedRecord {
+	return reservedRecord{&o.Status, &o.Reservation, "order", nanoca.OrderStatusProcessing}
+}
+
+func challengeRecord(c *nanoca.Challenge) reservedRecord {
+	return reservedRecord{&c.Status, &c.Reservation, "challenge", nanoca.ChallengeStatusProcessing}
+}
+
+// reserve transitions the record from `from` to processing — or reclaims a
+// processing record whose reservation has lapsed — recording token and the
+// reservation time.
+func (r reservedRecord) reserve(from, token string, lease time.Duration) error {
+	switch {
+	case *r.status == from:
+	case *r.status == r.processing && !(*r.reservation).Live(lease):
+	case *r.status == r.processing:
+		return fmt.Errorf("%s is already reserved: %w", r.resource, nanoca.ErrReserved)
+	default:
+		return fmt.Errorf("%s status is %s, not %s: %w", r.resource, *r.status, from, nanoca.ErrStatusMismatch)
+	}
+
+	*r.status = r.processing
+	*r.reservation = &nanoca.Reservation{Token: token, ReservedAt: time.Now()}
+	return nil
+}
+
+// fence admits a write only from the reservation's holder and clears the
+// reservation; the caller sets the resulting status.
+func (r reservedRecord) fence(token string) error {
+	if *r.status != r.processing {
+		return fmt.Errorf("%s status is %s, not %s: %w", r.resource, *r.status, r.processing, nanoca.ErrStatusMismatch)
+	}
+	if *r.reservation == nil || (*r.reservation).Token != token {
+		return fmt.Errorf("%s reservation is held by another token: %w", r.resource, nanoca.ErrReserved)
+	}
+	*r.reservation = nil
+	return nil
+}
+
 // ConsumeNonce atomically validates and consumes a nonce, preventing race conditions
 func (s *Storage) ConsumeNonce(_ context.Context, value string, expiry time.Duration) (*nanoca.Nonce, error) {
 	var nonce nanoca.Nonce
 
-	err := s.db.Update(func(txn *badger.Txn) error {
-		item, err := txn.Get(nonceKey(value))
-		if err != nil {
-			if errors.Is(err, badger.ErrKeyNotFound) {
-				return nanoca.ErrNonceNotFound
-			}
-			return fmt.Errorf("failed to get nonce: %w", err)
+	// The nonce is deleted even when expired; reporting expiry from inside
+	// the transaction would roll back the delete and keep the nonce forever.
+	err := s.update(func(txn *badger.Txn) error {
+		if err := getJSON(txn, nonceKey(value), "nonce", &nonce); err != nil {
+			return err
 		}
-
-		err = item.Value(func(val []byte) error {
-			return json.Unmarshal(val, &nonce)
-		})
-		if err != nil {
-			return fmt.Errorf("failed to unmarshal nonce: %w", err)
-		}
-
 		return txn.Delete(nonceKey(value))
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	// Expiry is reported only after the transaction commits: returning the
-	// error from inside it would roll back the delete and keep the expired
-	// nonce forever (nonce keys carry no TTL).
 	if time.Since(nonce.CreatedAt) > expiry {
 		return nil, nanoca.ErrNonceExpired
 	}
@@ -143,7 +222,18 @@ func putAccount(txn *badger.Txn, account *nanoca.Account) error {
 }
 
 func (s *Storage) CreateAccount(_ context.Context, account *nanoca.Account) error {
-	return s.db.Update(func(txn *badger.Txn) error {
+	// A concurrent registration of the same key surfaces as a conflict; the
+	// retry re-reads the thumbprint index and returns ErrAccountExists.
+	return s.update(func(txn *badger.Txn) error {
+		if account.KeyThumbprint != "" {
+			switch _, err := txn.Get(accountKeyLookupKey(account.KeyThumbprint)); {
+			case err == nil:
+				return nanoca.ErrAccountExists
+			case !errors.Is(err, badger.ErrKeyNotFound):
+				return fmt.Errorf("failed to get account key index: %w", err)
+			}
+		}
+
 		return putAccount(txn, account)
 	})
 }
@@ -152,20 +242,10 @@ func (s *Storage) GetAccount(_ context.Context, id string) (*nanoca.Account, err
 	var account nanoca.Account
 
 	err := s.db.View(func(txn *badger.Txn) error {
-		item, err := txn.Get(accountKey(id))
-		if err != nil {
-			return err
-		}
-
-		return item.Value(func(val []byte) error {
-			return json.Unmarshal(val, &account)
-		})
+		return getJSON(txn, accountKey(id), "account", &account)
 	})
 	if err != nil {
-		if errors.Is(err, badger.ErrKeyNotFound) {
-			return nil, errors.New("account not found")
-		}
-		return nil, fmt.Errorf("failed to get account: %w", err)
+		return nil, err
 	}
 
 	return &account, nil
@@ -175,32 +255,37 @@ func (s *Storage) GetAccountByKey(ctx context.Context, keyThumbprint string) (*n
 	var accountID string
 
 	err := s.db.View(func(txn *badger.Txn) error {
-		item, err := txn.Get(accountKeyLookupKey(keyThumbprint))
+		val, err := getValue(txn, accountKeyLookupKey(keyThumbprint), "account key index")
 		if err != nil {
 			return err
 		}
-
-		return item.Value(func(val []byte) error {
-			accountID = string(val)
-			return nil
-		})
+		accountID = string(val)
+		return nil
 	})
 	if err != nil {
-		if errors.Is(err, badger.ErrKeyNotFound) {
-			return nil, errors.New("account not found")
-		}
-		return nil, fmt.Errorf("failed to lookup account by key: %w", err)
+		return nil, err
 	}
 
 	return s.GetAccount(ctx, accountID)
 }
 
-func (s *Storage) UpdateAccount(ctx context.Context, account *nanoca.Account) error {
-	if _, err := s.GetAccount(ctx, account.ID); err != nil {
-		return errors.New("account not found")
+// requireKey ensures a record exists before it is overwritten, without
+// reading its value.
+func requireKey(txn *badger.Txn, key []byte, resource string) error {
+	if _, err := txn.Get(key); err != nil {
+		if errors.Is(err, badger.ErrKeyNotFound) {
+			return nanoca.ErrNotFound
+		}
+		return fmt.Errorf("failed to get %s: %w", resource, err)
 	}
+	return nil
+}
 
-	return s.db.Update(func(txn *badger.Txn) error {
+func (s *Storage) UpdateAccount(_ context.Context, account *nanoca.Account) error {
+	return s.update(func(txn *badger.Txn) error {
+		if err := requireKey(txn, accountKey(account.ID), "account"); err != nil {
+			return err
+		}
 		return putAccount(txn, account)
 	})
 }
@@ -220,38 +305,56 @@ func (s *Storage) GetOrder(_ context.Context, id string) (*nanoca.Order, error) 
 	var order nanoca.Order
 
 	err := s.db.View(func(txn *badger.Txn) error {
-		item, err := txn.Get(orderKey(id))
-		if err != nil {
-			return err
-		}
-
-		return item.Value(func(val []byte) error {
-			return json.Unmarshal(val, &order)
-		})
+		return getJSON(txn, orderKey(id), "order", &order)
 	})
 	if err != nil {
-		if errors.Is(err, badger.ErrKeyNotFound) {
-			return nil, errors.New("order not found")
-		}
-		return nil, fmt.Errorf("failed to get order: %w", err)
+		return nil, err
 	}
 
 	return &order, nil
 }
 
-func (s *Storage) UpdateOrder(ctx context.Context, order *nanoca.Order) error {
-	_, err := s.GetOrder(ctx, order.ID)
-	if err != nil {
-		return errors.New("order not found")
-	}
+func (s *Storage) SetOrderStatus(_ context.Context, id, from, to string) error {
+	return s.update(func(txn *badger.Txn) error {
+		var order nanoca.Order
+		if err := getJSON(txn, orderKey(id), "order", &order); err != nil {
+			return err
+		}
 
-	data, err := json.Marshal(order)
-	if err != nil {
-		return fmt.Errorf("failed to marshal order: %w", err)
-	}
+		if order.Status != from {
+			return fmt.Errorf("order status is %s, not %s: %w", order.Status, from, nanoca.ErrStatusMismatch)
+		}
+		order.Status = to
 
-	return s.db.Update(func(txn *badger.Txn) error {
-		return txn.Set(orderKey(order.ID), data)
+		return setJSON(txn, orderKey(id), "order", &order)
+	})
+}
+
+func (s *Storage) ReserveOrderFinalize(_ context.Context, id, token string, lease time.Duration) error {
+	return s.update(func(txn *badger.Txn) error {
+		var order nanoca.Order
+		if err := getJSON(txn, orderKey(id), "order", &order); err != nil {
+			return err
+		}
+		if err := orderRecord(&order).reserve(nanoca.OrderStatusReady, token, lease); err != nil {
+			return err
+		}
+		return setJSON(txn, orderKey(id), "order", &order)
+	})
+}
+
+func (s *Storage) ReleaseOrderFinalize(_ context.Context, id, token, to string) error {
+	return s.update(func(txn *badger.Txn) error {
+		var order nanoca.Order
+		if err := getJSON(txn, orderKey(id), "order", &order); err != nil {
+			return err
+		}
+		if err := orderRecord(&order).fence(token); err != nil {
+			return err
+		}
+		order.Status = to
+
+		return setJSON(txn, orderKey(id), "order", &order)
 	})
 }
 
@@ -305,38 +408,25 @@ func (s *Storage) GetAuthorization(_ context.Context, id string) (*nanoca.Author
 	var authz nanoca.Authorization
 
 	err := s.db.View(func(txn *badger.Txn) error {
-		item, err := txn.Get(authzKey(id))
-		if err != nil {
-			return err
-		}
-
-		return item.Value(func(val []byte) error {
-			return json.Unmarshal(val, &authz)
-		})
+		return getJSON(txn, authzKey(id), "authorization", &authz)
 	})
 	if err != nil {
-		if errors.Is(err, badger.ErrKeyNotFound) {
-			return nil, errors.New("authorization not found")
-		}
-		return nil, fmt.Errorf("failed to get authorization: %w", err)
+		return nil, err
 	}
 
 	return &authz, nil
 }
 
-func (s *Storage) UpdateAuthorization(ctx context.Context, authz *nanoca.Authorization) error {
-	_, err := s.GetAuthorization(ctx, authz.ID)
-	if err != nil {
-		return errors.New("authorization not found")
-	}
-
-	data, err := json.Marshal(authz)
-	if err != nil {
-		return fmt.Errorf("failed to marshal authorization: %w", err)
-	}
-
-	return s.db.Update(func(txn *badger.Txn) error {
-		return txn.Set(authzKey(authz.ID), data)
+func (s *Storage) SettleAuthorization(_ context.Context, authz *nanoca.Authorization) error {
+	return s.update(func(txn *badger.Txn) error {
+		var stored nanoca.Authorization
+		if err := getJSON(txn, authzKey(authz.ID), "authorization", &stored); err != nil {
+			return err
+		}
+		if stored.Status != nanoca.AuthzStatusPending {
+			return fmt.Errorf("authorization status is %s, not %s: %w", stored.Status, nanoca.AuthzStatusPending, nanoca.ErrStatusMismatch)
+		}
+		return setJSON(txn, authzKey(authz.ID), "authorization", authz)
 	})
 }
 
@@ -355,66 +445,45 @@ func (s *Storage) GetChallenge(_ context.Context, id string) (*nanoca.Challenge,
 	var challenge nanoca.Challenge
 
 	err := s.db.View(func(txn *badger.Txn) error {
-		item, err := txn.Get(challengeKey(id))
-		if err != nil {
-			return err
-		}
-
-		return item.Value(func(val []byte) error {
-			return json.Unmarshal(val, &challenge)
-		})
+		return getJSON(txn, challengeKey(id), "challenge", &challenge)
 	})
 	if err != nil {
-		if errors.Is(err, badger.ErrKeyNotFound) {
-			return nil, errors.New("challenge not found")
-		}
-		return nil, fmt.Errorf("failed to get challenge: %w", err)
+		return nil, err
 	}
 
 	return &challenge, nil
 }
 
-func (s *Storage) updateChallengeStatus(id, expectedStatus string, updateFn func(*nanoca.Challenge)) error {
-	return s.db.Update(func(txn *badger.Txn) error {
-		item, err := txn.Get(challengeKey(id))
-		if err != nil {
-			if errors.Is(err, badger.ErrKeyNotFound) {
-				return errors.New("challenge not found")
-			}
-			return fmt.Errorf("failed to get challenge: %w", err)
-		}
-
+func (s *Storage) ReserveChallengeValidation(_ context.Context, id, reservationToken string, lease time.Duration) error {
+	return s.update(func(txn *badger.Txn) error {
 		var challenge nanoca.Challenge
-		err = item.Value(func(val []byte) error {
-			return json.Unmarshal(val, &challenge)
-		})
-		if err != nil {
-			return fmt.Errorf("failed to unmarshal challenge: %w", err)
+		if err := getJSON(txn, challengeKey(id), "challenge", &challenge); err != nil {
+			return err
 		}
-
-		if challenge.Status != expectedStatus {
-			return fmt.Errorf("challenge status mismatch: expected %s, got %s", expectedStatus, challenge.Status)
+		if err := challengeRecord(&challenge).reserve(nanoca.ChallengeStatusPending, reservationToken, lease); err != nil {
+			return err
 		}
+		return setJSON(txn, challengeKey(id), "challenge", &challenge)
+	})
+}
 
+func (s *Storage) settleChallenge(id, reservationToken string, updateFn func(*nanoca.Challenge)) error {
+	return s.update(func(txn *badger.Txn) error {
+		var challenge nanoca.Challenge
+		if err := getJSON(txn, challengeKey(id), "challenge", &challenge); err != nil {
+			return err
+		}
+		if err := challengeRecord(&challenge).fence(reservationToken); err != nil {
+			return err
+		}
 		updateFn(&challenge)
 
-		data, err := json.Marshal(challenge)
-		if err != nil {
-			return fmt.Errorf("failed to marshal challenge: %w", err)
-		}
-
-		return txn.Set(challengeKey(id), data)
+		return setJSON(txn, challengeKey(id), "challenge", &challenge)
 	})
 }
 
-func (s *Storage) SetChallengeProcessing(_ context.Context, id string) error {
-	return s.updateChallengeStatus(id, nanoca.ChallengeStatusPending, func(c *nanoca.Challenge) {
-		c.Status = nanoca.ChallengeStatusProcessing
-	})
-}
-
-func (s *Storage) SetChallengeValid(_ context.Context, id string, validated time.Time, attestation map[string]any) error {
-	return s.updateChallengeStatus(id, nanoca.ChallengeStatusProcessing, func(c *nanoca.Challenge) {
+func (s *Storage) SetChallengeValid(_ context.Context, id, reservationToken string, validated time.Time, attestation []byte) error {
+	return s.settleChallenge(id, reservationToken, func(c *nanoca.Challenge) {
 		c.Status = nanoca.ChallengeStatusValid
 		c.Validated = &validated
 		c.Attestation = attestation
@@ -422,22 +491,37 @@ func (s *Storage) SetChallengeValid(_ context.Context, id string, validated time
 	})
 }
 
-func (s *Storage) SetChallengeInvalid(_ context.Context, id string, validated time.Time, problem *nanoca.Problem) error {
-	return s.updateChallengeStatus(id, nanoca.ChallengeStatusProcessing, func(c *nanoca.Challenge) {
+func (s *Storage) SetChallengeInvalid(_ context.Context, id, reservationToken string, validated time.Time, problem *nanoca.Problem) error {
+	return s.settleChallenge(id, reservationToken, func(c *nanoca.Challenge) {
 		c.Status = nanoca.ChallengeStatusInvalid
 		c.Validated = &validated
 		c.Error = problem
 	})
 }
 
-func (s *Storage) CreateCertificate(_ context.Context, cert *nanoca.Certificate) error {
-	data, err := json.Marshal(cert)
-	if err != nil {
-		return fmt.Errorf("failed to marshal certificate: %w", err)
-	}
+func (s *Storage) ReleaseChallengeValidation(_ context.Context, id, reservationToken string) error {
+	return s.settleChallenge(id, reservationToken, func(c *nanoca.Challenge) {
+		c.Status = nanoca.ChallengeStatusPending
+	})
+}
 
-	return s.db.Update(func(txn *badger.Txn) error {
-		return txn.Set(certificateKey(cert.SerialNumber), data)
+func (s *Storage) CompleteOrder(_ context.Context, order *nanoca.Order, cert *nanoca.Certificate, token string) error {
+	completed := *order
+	completed.Reservation = nil
+
+	return s.update(func(txn *badger.Txn) error {
+		var stored nanoca.Order
+		if err := getJSON(txn, orderKey(order.ID), "order", &stored); err != nil {
+			return err
+		}
+		if err := orderRecord(&stored).fence(token); err != nil {
+			return err
+		}
+
+		if err := setJSON(txn, orderKey(order.ID), "order", &completed); err != nil {
+			return err
+		}
+		return setJSON(txn, certificateKey(cert.ID), "certificate", cert)
 	})
 }
 
@@ -445,32 +529,18 @@ func (s *Storage) GetCertificate(_ context.Context, id string) (*nanoca.Certific
 	var cert nanoca.Certificate
 
 	err := s.db.View(func(txn *badger.Txn) error {
-		item, err := txn.Get(certificateKey(id))
-		if err != nil {
-			return err
-		}
-
-		return item.Value(func(val []byte) error {
-			if err := json.Unmarshal(val, &cert); err != nil {
-				return err
-			}
-
-			if len(cert.Raw) > 0 {
-				x509Cert, err := x509.ParseCertificate(cert.Raw)
-				if err != nil {
-					return fmt.Errorf("failed to parse certificate from raw bytes: %w", err)
-				}
-				cert.Certificate = x509Cert
-			}
-
-			return nil
-		})
+		return getJSON(txn, certificateKey(id), "certificate", &cert)
 	})
 	if err != nil {
-		if errors.Is(err, badger.ErrKeyNotFound) {
-			return nil, errors.New("certificate not found")
+		return nil, err
+	}
+
+	if len(cert.Raw) > 0 {
+		x509Cert, err := x509.ParseCertificate(cert.Raw)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse certificate from raw bytes: %w", err)
 		}
-		return nil, fmt.Errorf("failed to get certificate: %w", err)
+		cert.Certificate = x509Cert
 	}
 
 	return &cert, nil

--- a/storage/badger/storage_test.go
+++ b/storage/badger/storage_test.go
@@ -3,6 +3,7 @@ package badger
 import (
 	"crypto/x509"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -87,8 +88,8 @@ func TestStorage_NonceOperations(t *testing.T) {
 	if err == nil {
 		t.Error("ConsumeNonce() should fail for already consumed nonce")
 	}
-	if !errors.Is(err, nanoca.ErrNonceNotFound) {
-		t.Errorf("ConsumeNonce() error = %v, want ErrNonceNotFound", err)
+	if !errors.Is(err, nanoca.ErrNotFound) {
+		t.Errorf("ConsumeNonce() error = %v, want ErrNotFound", err)
 	}
 
 	expiredNonce := &nanoca.Nonce{
@@ -103,6 +104,63 @@ func TestStorage_NonceOperations(t *testing.T) {
 	}
 	if !errors.Is(err, nanoca.ErrNonceExpired) {
 		t.Errorf("ConsumeNonce() error = %v, want ErrNonceExpired", err)
+	}
+}
+
+// Handlers either drop UpdateAccount errors or surface them as 500s, so
+// concurrent updates to one record must not fail spuriously (e.g. with
+// badger.ErrConflict from the existence check sharing the write txn).
+func TestStorage_ConcurrentAccountUpdates(t *testing.T) {
+	t.Parallel()
+
+	storage := newTestStorage(t)
+	ctx := t.Context()
+
+	if err := storage.CreateAccount(ctx, &nanoca.Account{ID: "a1"}); err != nil {
+		t.Fatalf("CreateAccount() error = %v", err)
+	}
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 4)
+	for range 4 {
+		wg.Go(func() {
+			for range 200 {
+				if err := storage.UpdateAccount(ctx, &nanoca.Account{ID: "a1", Status: "valid"}); err != nil {
+					errs <- err
+					return
+				}
+			}
+		})
+	}
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		t.Errorf("UpdateAccount() error = %v", err)
+	}
+}
+
+func TestStorage_CreateAccountDuplicateKey(t *testing.T) {
+	t.Parallel()
+
+	storage := newTestStorage(t)
+	ctx := t.Context()
+
+	if err := storage.CreateAccount(ctx, &nanoca.Account{ID: "first", KeyThumbprint: "thumb"}); err != nil {
+		t.Fatalf("CreateAccount() error = %v", err)
+	}
+
+	err := storage.CreateAccount(ctx, &nanoca.Account{ID: "second", KeyThumbprint: "thumb"})
+	if !errors.Is(err, nanoca.ErrAccountExists) {
+		t.Errorf("CreateAccount() error = %v, want ErrAccountExists", err)
+	}
+
+	retrieved, err := storage.GetAccountByKey(ctx, "thumb")
+	if err != nil {
+		t.Fatalf("GetAccountByKey() error = %v", err)
+	}
+	if retrieved.ID != "first" {
+		t.Errorf("GetAccountByKey() ID = %v, want first", retrieved.ID)
 	}
 }
 
@@ -194,10 +252,9 @@ func TestStorage_OrderOperations(t *testing.T) {
 		t.Errorf("GetOrder() ID = %v, want %v", retrieved.ID, order.ID)
 	}
 
-	order.Status = "ready"
-	err = storage.UpdateOrder(ctx, order)
+	err = storage.SetOrderStatus(ctx, order.ID, nanoca.OrderStatusPending, nanoca.OrderStatusReady)
 	if err != nil {
-		t.Errorf("UpdateOrder() error = %v", err)
+		t.Errorf("SetOrderStatus() error = %v", err)
 	}
 
 	retrieved, err = storage.GetOrder(ctx, order.ID)
@@ -205,7 +262,7 @@ func TestStorage_OrderOperations(t *testing.T) {
 		t.Errorf("GetOrder() after update error = %v", err)
 	}
 	if retrieved.Status != "ready" {
-		t.Errorf("UpdateOrder() status = %v, want ready", retrieved.Status)
+		t.Errorf("SetOrderStatus() status = %v, want ready", retrieved.Status)
 	}
 
 	orders, err := storage.GetOrdersByAccount(ctx, order.AccountID)
@@ -222,12 +279,6 @@ func TestStorage_OrderOperations(t *testing.T) {
 	_, err = storage.GetOrder(ctx, "nonexistent")
 	if err == nil {
 		t.Error("GetOrder() should fail for nonexistent order")
-	}
-
-	nonExistent := &nanoca.Order{ID: "nonexistent"}
-	err = storage.UpdateOrder(ctx, nonExistent)
-	if err == nil {
-		t.Error("UpdateOrder() should fail for nonexistent order")
 	}
 }
 
@@ -259,17 +310,24 @@ func TestStorage_AuthorizationOperations(t *testing.T) {
 	}
 
 	authz.Status = "valid"
-	err = storage.UpdateAuthorization(ctx, authz)
+	err = storage.SettleAuthorization(ctx, authz)
 	if err != nil {
-		t.Errorf("UpdateAuthorization() error = %v", err)
+		t.Errorf("SettleAuthorization() error = %v", err)
 	}
 
 	retrieved, err = storage.GetAuthorization(ctx, authz.ID)
 	if err != nil {
-		t.Errorf("GetAuthorization() after update error = %v", err)
+		t.Errorf("GetAuthorization() after settle error = %v", err)
 	}
 	if retrieved.Status != "valid" {
-		t.Errorf("UpdateAuthorization() status = %v, want valid", retrieved.Status)
+		t.Errorf("SettleAuthorization() status = %v, want valid", retrieved.Status)
+	}
+
+	// The guard is what keeps a recompute from stale reads from
+	// overwriting a settled authorization.
+	authz.Status = "invalid"
+	if err := storage.SettleAuthorization(ctx, authz); !errors.Is(err, nanoca.ErrStatusMismatch) {
+		t.Errorf("SettleAuthorization(settled) error = %v, want ErrStatusMismatch", err)
 	}
 
 	_, err = storage.GetAuthorization(ctx, "nonexistent")
@@ -278,9 +336,9 @@ func TestStorage_AuthorizationOperations(t *testing.T) {
 	}
 
 	nonExistent := &nanoca.Authorization{ID: "nonexistent"}
-	err = storage.UpdateAuthorization(ctx, nonExistent)
+	err = storage.SettleAuthorization(ctx, nonExistent)
 	if err == nil {
-		t.Error("UpdateAuthorization() should fail for nonexistent authorization")
+		t.Error("SettleAuthorization() should fail for nonexistent authorization")
 	}
 }
 
@@ -321,7 +379,7 @@ func TestStorage_ChallengeOperations(t *testing.T) {
 		}
 	})
 
-	t.Run("SetChallengeProcessing", func(t *testing.T) {
+	t.Run("ReserveChallengeValidation", func(t *testing.T) {
 		t.Parallel()
 
 		storage := newTestStorage(t)
@@ -337,8 +395,8 @@ func TestStorage_ChallengeOperations(t *testing.T) {
 			t.Fatalf("CreateChallenge() error = %v", err)
 		}
 
-		if err := storage.SetChallengeProcessing(ctx, challenge.ID); err != nil {
-			t.Fatalf("SetChallengeProcessing() error = %v", err)
+		if err := storage.ReserveChallengeValidation(ctx, challenge.ID, "t1", time.Minute); err != nil {
+			t.Fatalf("ReserveChallengeValidation() error = %v", err)
 		}
 
 		retrieved, err := storage.GetChallenge(ctx, challenge.ID)
@@ -348,15 +406,31 @@ func TestStorage_ChallengeOperations(t *testing.T) {
 		if retrieved.Status != "processing" {
 			t.Errorf("Status = %v, want processing", retrieved.Status)
 		}
+		if retrieved.Reservation == nil || retrieved.Reservation.Token != "t1" {
+			t.Errorf("Reservation = %+v, want token t1", retrieved.Reservation)
+		}
 
-		// calling again should fail (status is now processing, not pending)
-		if err := storage.SetChallengeProcessing(ctx, challenge.ID); err == nil {
-			t.Error("SetChallengeProcessing() should fail when status is not pending")
+		// a live reservation refuses a second holder
+		if err := storage.ReserveChallengeValidation(ctx, challenge.ID, "t2", time.Minute); !errors.Is(err, nanoca.ErrReserved) {
+			t.Errorf("ReserveChallengeValidation(reserved) error = %v, want ErrReserved", err)
+		}
+
+		// a negative lease makes the reservation already expired: a retried
+		// POST reclaims a validation interrupted before a terminal status
+		if err := storage.ReserveChallengeValidation(ctx, challenge.ID, "t2", -time.Second); err != nil {
+			t.Errorf("ReserveChallengeValidation(expired) error = %v, want success", err)
+		}
+		retrieved, err = storage.GetChallenge(ctx, challenge.ID)
+		if err != nil {
+			t.Fatalf("GetChallenge() error = %v", err)
+		}
+		if retrieved.Reservation == nil || retrieved.Reservation.Token != "t2" {
+			t.Errorf("Reservation after reclaim = %+v, want token t2", retrieved.Reservation)
 		}
 
 		// nonexistent challenge
-		if err := storage.SetChallengeProcessing(ctx, "nonexistent"); err == nil {
-			t.Error("SetChallengeProcessing() should fail for nonexistent challenge")
+		if err := storage.ReserveChallengeValidation(ctx, "nonexistent", "t1", time.Minute); err == nil {
+			t.Error("ReserveChallengeValidation() should fail for nonexistent challenge")
 		}
 	})
 
@@ -375,13 +449,19 @@ func TestStorage_ChallengeOperations(t *testing.T) {
 		if err := storage.CreateChallenge(ctx, challenge); err != nil {
 			t.Fatalf("CreateChallenge() error = %v", err)
 		}
-		if err := storage.SetChallengeProcessing(ctx, challenge.ID); err != nil {
-			t.Fatalf("SetChallengeProcessing() error = %v", err)
+		if err := storage.ReserveChallengeValidation(ctx, challenge.ID, "t1", time.Minute); err != nil {
+			t.Fatalf("ReserveChallengeValidation() error = %v", err)
 		}
 
 		now := time.Now()
-		attestation := map[string]any{"fmt": "none", "key": "value"}
-		if err := storage.SetChallengeValid(ctx, challenge.ID, now, attestation); err != nil {
+		attestation := []byte("attestation-object")
+
+		// the write is fenced: a stale holder's token is rejected
+		if err := storage.SetChallengeValid(ctx, challenge.ID, "stale", now, attestation); !errors.Is(err, nanoca.ErrReserved) {
+			t.Errorf("SetChallengeValid(stale token) error = %v, want ErrReserved", err)
+		}
+
+		if err := storage.SetChallengeValid(ctx, challenge.ID, "t1", now, attestation); err != nil {
 			t.Fatalf("SetChallengeValid() error = %v", err)
 		}
 
@@ -401,14 +481,17 @@ func TestStorage_ChallengeOperations(t *testing.T) {
 		if retrieved.Error != nil {
 			t.Error("Error should be nil")
 		}
+		if retrieved.Reservation != nil {
+			t.Error("Reservation should be cleared by the terminal write")
+		}
 
 		// calling on a valid challenge should fail (expects processing)
-		if err := storage.SetChallengeValid(ctx, challenge.ID, now, nil); err == nil {
+		if err := storage.SetChallengeValid(ctx, challenge.ID, "t1", now, nil); err == nil {
 			t.Error("SetChallengeValid() should fail when status is not processing")
 		}
 
 		// nonexistent challenge
-		if err := storage.SetChallengeValid(ctx, "nonexistent", now, nil); err == nil {
+		if err := storage.SetChallengeValid(ctx, "nonexistent", "t1", now, nil); err == nil {
 			t.Error("SetChallengeValid() should fail for nonexistent challenge")
 		}
 	})
@@ -428,13 +511,18 @@ func TestStorage_ChallengeOperations(t *testing.T) {
 		if err := storage.CreateChallenge(ctx, challenge); err != nil {
 			t.Fatalf("CreateChallenge() error = %v", err)
 		}
-		if err := storage.SetChallengeProcessing(ctx, challenge.ID); err != nil {
-			t.Fatalf("SetChallengeProcessing() error = %v", err)
+		if err := storage.ReserveChallengeValidation(ctx, challenge.ID, "t1", time.Minute); err != nil {
+			t.Fatalf("ReserveChallengeValidation() error = %v", err)
 		}
 
 		now := time.Now()
 		prob := nanoca.Unauthorized("device not authorized")
-		if err := storage.SetChallengeInvalid(ctx, challenge.ID, now, prob); err != nil {
+
+		if err := storage.SetChallengeInvalid(ctx, challenge.ID, "stale", now, prob); !errors.Is(err, nanoca.ErrReserved) {
+			t.Errorf("SetChallengeInvalid(stale token) error = %v, want ErrReserved", err)
+		}
+
+		if err := storage.SetChallengeInvalid(ctx, challenge.ID, "t1", now, prob); err != nil {
 			t.Fatalf("SetChallengeInvalid() error = %v", err)
 		}
 
@@ -451,17 +539,37 @@ func TestStorage_ChallengeOperations(t *testing.T) {
 		if retrieved.Error == nil {
 			t.Error("Error should be set")
 		}
+		if retrieved.Reservation != nil {
+			t.Error("Reservation should be cleared by the terminal write")
+		}
 
 		// calling on an invalid challenge should fail (expects processing)
-		if err := storage.SetChallengeInvalid(ctx, challenge.ID, now, prob); err == nil {
+		if err := storage.SetChallengeInvalid(ctx, challenge.ID, "t1", now, prob); err == nil {
 			t.Error("SetChallengeInvalid() should fail when status is not processing")
 		}
 
 		// nonexistent challenge
-		if err := storage.SetChallengeInvalid(ctx, "nonexistent", now, prob); err == nil {
+		if err := storage.SetChallengeInvalid(ctx, "nonexistent", "t1", now, prob); err == nil {
 			t.Error("SetChallengeInvalid() should fail for nonexistent challenge")
 		}
 	})
+}
+
+// storeCertificate persists a certificate the way the CA does: by reserving
+// and completing a ready order.
+func storeCertificate(t *testing.T, s *Storage, cert *nanoca.Certificate) {
+	t.Helper()
+	ctx := t.Context()
+
+	if err := s.CreateOrder(ctx, &nanoca.Order{ID: cert.ID, Status: nanoca.OrderStatusReady}); err != nil {
+		t.Fatalf("CreateOrder() error = %v", err)
+	}
+	if err := s.ReserveOrderFinalize(ctx, cert.ID, "token", time.Minute); err != nil {
+		t.Fatalf("ReserveOrderFinalize() error = %v", err)
+	}
+	if err := s.CompleteOrder(ctx, &nanoca.Order{ID: cert.ID, Status: nanoca.OrderStatusValid}, cert, "token"); err != nil {
+		t.Fatalf("CompleteOrder() error = %v", err)
+	}
 }
 
 func TestStorage_CertificateOperations(t *testing.T) {
@@ -471,17 +579,14 @@ func TestStorage_CertificateOperations(t *testing.T) {
 
 	ctx := t.Context()
 	cert := &nanoca.Certificate{
+		ID:           "order-1",
 		SerialNumber: "test-cert-123",
 		Raw:          []byte("dummy-cert-data"),
 		Certificate:  &x509.Certificate{},
 	}
+	storeCertificate(t, storage, cert)
 
-	err := storage.CreateCertificate(ctx, cert)
-	if err != nil {
-		t.Errorf("CreateCertificate() error = %v", err)
-	}
-
-	_, err = storage.GetCertificate(ctx, cert.SerialNumber)
+	_, err := storage.GetCertificate(ctx, cert.ID)
 	if err == nil {
 		t.Error("GetCertificate() should fail with dummy certificate data")
 	}
@@ -489,6 +594,180 @@ func TestStorage_CertificateOperations(t *testing.T) {
 	_, err = storage.GetCertificate(ctx, "nonexistent")
 	if err == nil {
 		t.Error("GetCertificate() should fail for nonexistent certificate")
+	}
+}
+
+func TestStorage_CompleteOrder(t *testing.T) {
+	t.Parallel()
+
+	storage := newTestStorage(t)
+	ctx := t.Context()
+
+	if err := storage.CreateOrder(ctx, &nanoca.Order{ID: "o1", Status: nanoca.OrderStatusPending}); err != nil {
+		t.Fatalf("CreateOrder() error = %v", err)
+	}
+	order := &nanoca.Order{ID: "o1", Status: nanoca.OrderStatusValid}
+	cert := &nanoca.Certificate{ID: "o1", SerialNumber: "1"}
+
+	// Completion requires a reserved (processing) order.
+	if err := storage.CompleteOrder(ctx, order, cert, "t1"); !errors.Is(err, nanoca.ErrStatusMismatch) {
+		t.Errorf("CompleteOrder(pending) error = %v, want ErrStatusMismatch", err)
+	}
+	if err := storage.SetOrderStatus(ctx, "o1", nanoca.OrderStatusPending, nanoca.OrderStatusReady); err != nil {
+		t.Fatalf("SetOrderStatus() error = %v", err)
+	}
+	if err := storage.CompleteOrder(ctx, order, cert, "t1"); !errors.Is(err, nanoca.ErrStatusMismatch) {
+		t.Errorf("CompleteOrder(ready, unreserved) error = %v, want ErrStatusMismatch", err)
+	}
+	if _, err := storage.GetCertificate(ctx, "o1"); !errors.Is(err, nanoca.ErrNotFound) {
+		t.Errorf("GetCertificate() after failed completion error = %v, want ErrNotFound", err)
+	}
+
+	if err := storage.ReserveOrderFinalize(ctx, "o1", "t1", time.Minute); err != nil {
+		t.Fatalf("ReserveOrderFinalize() error = %v", err)
+	}
+	if err := storage.CompleteOrder(ctx, order, cert, "stale"); !errors.Is(err, nanoca.ErrReserved) {
+		t.Errorf("CompleteOrder(stale token) error = %v, want ErrReserved", err)
+	}
+	if err := storage.CompleteOrder(ctx, order, cert, "t1"); err != nil {
+		t.Fatalf("CompleteOrder() error = %v", err)
+	}
+
+	got, err := storage.GetOrder(ctx, "o1")
+	if err != nil {
+		t.Fatalf("GetOrder() error = %v", err)
+	}
+	if got.Status != nanoca.OrderStatusValid {
+		t.Errorf("order status = %q, want %q", got.Status, nanoca.OrderStatusValid)
+	}
+	if got.Reservation != nil {
+		t.Error("Reservation should be cleared by completion")
+	}
+	if _, err := storage.GetCertificate(ctx, "o1"); err != nil {
+		t.Errorf("GetCertificate() error = %v", err)
+	}
+
+	if err := storage.CompleteOrder(ctx, order, cert, "t1"); !errors.Is(err, nanoca.ErrStatusMismatch) {
+		t.Errorf("CompleteOrder(valid) error = %v, want ErrStatusMismatch", err)
+	}
+}
+
+func TestReserveOrderFinalize(t *testing.T) {
+	t.Parallel()
+
+	storage := newTestStorage(t)
+	ctx := t.Context()
+
+	if err := storage.CreateOrder(ctx, &nanoca.Order{ID: "o1", Status: nanoca.OrderStatusPending}); err != nil {
+		t.Fatalf("CreateOrder() error = %v", err)
+	}
+	if err := storage.ReserveOrderFinalize(ctx, "o1", "t1", time.Minute); !errors.Is(err, nanoca.ErrStatusMismatch) {
+		t.Errorf("ReserveOrderFinalize(pending) error = %v, want ErrStatusMismatch", err)
+	}
+
+	if err := storage.SetOrderStatus(ctx, "o1", nanoca.OrderStatusPending, nanoca.OrderStatusReady); err != nil {
+		t.Fatalf("SetOrderStatus() error = %v", err)
+	}
+	if err := storage.ReserveOrderFinalize(ctx, "o1", "t1", time.Minute); err != nil {
+		t.Fatalf("ReserveOrderFinalize() error = %v", err)
+	}
+
+	order, err := storage.GetOrder(ctx, "o1")
+	if err != nil {
+		t.Fatalf("GetOrder() error = %v", err)
+	}
+	if order.Status != nanoca.OrderStatusProcessing {
+		t.Errorf("order status = %q, want %q", order.Status, nanoca.OrderStatusProcessing)
+	}
+	if order.Reservation == nil || order.Reservation.Token != "t1" {
+		t.Errorf("Reservation = %+v, want token t1", order.Reservation)
+	}
+
+	if err := storage.ReserveOrderFinalize(ctx, "o1", "t2", time.Minute); !errors.Is(err, nanoca.ErrReserved) {
+		t.Errorf("ReserveOrderFinalize(reserved) error = %v, want ErrReserved", err)
+	}
+
+	// A negative lease makes the reservation already expired: a retry
+	// reclaims a finalize abandoned by a crashed holder.
+	if err := storage.ReserveOrderFinalize(ctx, "o1", "t2", -time.Second); err != nil {
+		t.Errorf("ReserveOrderFinalize(expired) error = %v, want success", err)
+	}
+	order, err = storage.GetOrder(ctx, "o1")
+	if err != nil {
+		t.Fatalf("GetOrder() error = %v", err)
+	}
+	if order.Reservation == nil || order.Reservation.Token != "t2" {
+		t.Errorf("Reservation after reclaim = %+v, want token t2", order.Reservation)
+	}
+}
+
+func TestReleaseOrderFinalize(t *testing.T) {
+	t.Parallel()
+
+	storage := newTestStorage(t)
+	ctx := t.Context()
+
+	if err := storage.CreateOrder(ctx, &nanoca.Order{ID: "o1", Status: nanoca.OrderStatusReady}); err != nil {
+		t.Fatalf("CreateOrder() error = %v", err)
+	}
+	if err := storage.ReleaseOrderFinalize(ctx, "o1", "t1", nanoca.OrderStatusReady); !errors.Is(err, nanoca.ErrStatusMismatch) {
+		t.Errorf("ReleaseOrderFinalize(ready) error = %v, want ErrStatusMismatch", err)
+	}
+
+	if err := storage.ReserveOrderFinalize(ctx, "o1", "t1", time.Minute); err != nil {
+		t.Fatalf("ReserveOrderFinalize() error = %v", err)
+	}
+	if err := storage.ReleaseOrderFinalize(ctx, "o1", "stale", nanoca.OrderStatusReady); !errors.Is(err, nanoca.ErrReserved) {
+		t.Errorf("ReleaseOrderFinalize(stale token) error = %v, want ErrReserved", err)
+	}
+	if err := storage.ReleaseOrderFinalize(ctx, "o1", "t1", nanoca.OrderStatusReady); err != nil {
+		t.Fatalf("ReleaseOrderFinalize() error = %v", err)
+	}
+
+	order, err := storage.GetOrder(ctx, "o1")
+	if err != nil {
+		t.Fatalf("GetOrder() error = %v", err)
+	}
+	if order.Status != nanoca.OrderStatusReady {
+		t.Errorf("order status = %q, want %q", order.Status, nanoca.OrderStatusReady)
+	}
+	if order.Reservation != nil {
+		t.Error("Reservation should be cleared by release")
+	}
+}
+
+func TestReleaseChallengeValidation(t *testing.T) {
+	t.Parallel()
+
+	storage := newTestStorage(t)
+	ctx := t.Context()
+
+	if err := storage.CreateChallenge(ctx, &nanoca.Challenge{ID: "c1", Status: nanoca.ChallengeStatusPending}); err != nil {
+		t.Fatalf("CreateChallenge() error = %v", err)
+	}
+	if err := storage.ReleaseChallengeValidation(ctx, "c1", "t1"); !errors.Is(err, nanoca.ErrStatusMismatch) {
+		t.Errorf("ReleaseChallengeValidation(pending) error = %v, want ErrStatusMismatch", err)
+	}
+
+	if err := storage.ReserveChallengeValidation(ctx, "c1", "t1", time.Minute); err != nil {
+		t.Fatalf("ReserveChallengeValidation() error = %v", err)
+	}
+	if err := storage.ReleaseChallengeValidation(ctx, "c1", "stale"); !errors.Is(err, nanoca.ErrReserved) {
+		t.Errorf("ReleaseChallengeValidation(stale token) error = %v, want ErrReserved", err)
+	}
+	if err := storage.ReleaseChallengeValidation(ctx, "c1", "t1"); err != nil {
+		t.Fatalf("ReleaseChallengeValidation() error = %v", err)
+	}
+
+	challenge, err := storage.GetChallenge(ctx, "c1")
+	if err != nil {
+		t.Fatalf("GetChallenge() error = %v", err)
+	}
+	if challenge.Status != nanoca.ChallengeStatusPending {
+		t.Errorf("challenge status = %q, want %q", challenge.Status, nanoca.ChallengeStatusPending)
+	}
+	if challenge.Reservation != nil {
+		t.Error("Reservation should be cleared by release")
 	}
 }
 

--- a/types.go
+++ b/types.go
@@ -54,9 +54,11 @@ type HardwareModule struct {
 // certificate response is built by ServedChain, which omits the root.
 type Certificate struct {
 	*x509.Certificate `json:"-"`
-	Raw               []byte   `json:"raw"`
-	SerialNumber      string   `json:"serialNumber"`
-	ChainRaw          [][]byte `json:"chainRaw,omitempty"`
+	// ID is the storage and URL identifier; the CA sets it to the order ID.
+	ID           string   `json:"id"`
+	Raw          []byte   `json:"raw"`
+	SerialNumber string   `json:"serialNumber"`
+	ChainRaw     [][]byte `json:"chainRaw,omitempty"`
 }
 
 // ServedChain returns the DER certificates for the ACME certificate response:
@@ -109,14 +111,14 @@ type Nonce struct {
 }
 
 type Account struct {
-	ID                   string           `json:"id"`                      // Include in storage
-	Key                  *jose.JSONWebKey `json:"key,omitempty"`           // Include in storage
-	KeyThumbprint        string           `json:"keyThumbprint,omitempty"` // Include in storage
+	ID                   string           `json:"id"`
+	Key                  *jose.JSONWebKey `json:"key,omitempty"`
+	KeyThumbprint        string           `json:"keyThumbprint,omitempty"`
 	Status               string           `json:"status"`
 	Contact              []string         `json:"contact,omitempty"`
 	TermsOfServiceAgreed bool             `json:"termsOfServiceAgreed,omitempty"`
 	Orders               string           `json:"orders,omitempty"`
-	CreatedAt            time.Time        `json:"createdAt"` // Include in storage
+	CreatedAt            time.Time        `json:"createdAt"`
 }
 
 type AccountRequest struct {
@@ -128,6 +130,22 @@ type AccountRequest struct {
 type Identifier struct {
 	Type  string `json:"type"`
 	Value string `json:"value"`
+}
+
+// Reservation marks a record as exclusively held by one in-flight operation.
+// It is persisted by storage but scrubbed from ACME responses; a reservation
+// older than the configured lease was abandoned by a crashed holder and may
+// be reclaimed.
+type Reservation struct {
+	Token      string    `json:"token"`
+	ReservedAt time.Time `json:"reservedAt"`
+}
+
+// Live reports whether the reservation is still honored under lease. A nil
+// reservation on a processing record counts as expired so a malformed
+// record can be reclaimed rather than wedged.
+func (r *Reservation) Live(lease time.Duration) bool {
+	return r != nil && time.Since(r.ReservedAt) <= lease
 }
 
 type Order struct {
@@ -143,6 +161,7 @@ type Order struct {
 	Certificate    string       `json:"certificate,omitempty"`
 	AccountID      string       `json:"accountId"`
 	CreatedAt      time.Time    `json:"createdAt"`
+	Reservation    *Reservation `json:"reservation,omitempty"`
 }
 
 type OrderRequest struct {
@@ -187,8 +206,12 @@ type Challenge struct {
 	ID        string     `json:"id"`
 	AuthzID   string     `json:"authzId"`
 	CreatedAt time.Time  `json:"createdAt"`
-	// Device attestation specific fields
-	Attestation map[string]any `json:"attestation,omitempty"`
+	// Attestation holds the raw CBOR attestation object from the validated
+	// challenge response, verbatim: finalize re-verifies it, and a decoded
+	// copy would not survive storage serialization intact (CBOR byte
+	// strings do not round-trip through JSON).
+	Attestation []byte       `json:"attestation,omitempty"`
+	Reservation *Reservation `json:"reservation,omitempty"`
 }
 
 type ChallengeRequest struct {


### PR DESCRIPTION
Export ErrNotFound, ErrAccountExists, ErrReserved, and ErrStatusMismatch and document them on the Storage interface. Handlers can now tell a missing record from a backend failure, so storage errors surface as 500s instead of 400s, and a registration race on one key returns the existing account instead of creating a duplicate.

Finalize takes a lease-based reservation, so only one request can finalize an order at a time even across processes sharing the store; if the holder crashes, the lease expires and a retry reclaims the order. The certificate is written in the same transaction that marks the order valid. Challenge and authorization status writes are guarded so a stale recompute can't overwrite a result that is already settled. Drop the unused UpdateOrder and NonceValidationError.