### PR TITLE
fix(handlers): return accurate problem documents from finalize and new-order

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -328,7 +328,7 @@ func (ca *CA) handleNewOrder(w http.ResponseWriter, r *http.Request) {
 
 	order, err := ca.createOrder(ctx, postData.accountID, orderReq)
 	if err != nil {
-		ca.writeProblem(ctx, w, Malformed("Failed to create order"))
+		ca.writeProblem(ctx, w, InternalServerError("Failed to create order"))
 		return
 	}
 	ctx = WithOrderID(ctx, order.ID)
@@ -390,7 +390,14 @@ func (ca *CA) handleOrderFinalize(ctx context.Context, w http.ResponseWriter, or
 	}
 
 	if err := ca.finalizeCertificate(ctx, orderID, postData.accountID, finalizeReq.CSR); err != nil {
-		ca.writeProblem(ctx, w, Malformed("Failed to finalize certificate"))
+		if prob, ok := errors.AsType[*Problem](err); ok {
+			ca.writeProblem(ctx, w, prob)
+		} else {
+			// writeProblem logs only the generic detail; without this line
+			// the cause of the 500 is lost.
+			ca.logger.ErrorContext(ctx, "Failed to finalize certificate", "error", err)
+			ca.writeProblem(ctx, w, InternalServerError("Failed to finalize certificate"))
+		}
 		return
 	}
 
@@ -934,12 +941,12 @@ func (ca *CA) finalizeCertificate(ctx context.Context, orderID, accountID string
 	// base64url-encoded version of the DER format."
 	csrDER, err := base64.RawURLEncoding.DecodeString(csrB64)
 	if err != nil {
-		return fmt.Errorf("invalid CSR base64url encoding: %w", err)
+		return BadCSR("Invalid CSR base64url encoding")
 	}
 
 	csr, err := x509.ParseCertificateRequest(csrDER)
 	if err != nil {
-		return fmt.Errorf("failed to parse CSR: %w", err)
+		return BadCSR("Failed to parse CSR")
 	}
 
 	if err := csr.CheckSignature(); err != nil {
@@ -948,15 +955,15 @@ func (ca *CA) finalizeCertificate(ctx context.Context, orderID, accountID string
 
 	order, err := ca.storage.GetOrder(ctx, orderID)
 	if err != nil {
-		return errors.New("order not found")
+		return Malformed("Order not found")
 	}
 
 	if order.AccountID != accountID {
-		return errors.New("order does not belong to account")
+		return Unauthorized("Order does not belong to account")
 	}
 
 	if order.Status != OrderStatusReady {
-		return errors.New("order is not ready for finalization")
+		return OrderNotReady("Order is not ready for finalization")
 	}
 
 	var deviceInfos []*DeviceInfo

--- a/handlers_finalize_test.go
+++ b/handlers_finalize_test.go
@@ -8,6 +8,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"errors"
+	"net/http"
 	"net/http/httptest"
 	"testing"
 
@@ -77,6 +78,8 @@ func TestFinalizeObserverErrorStillIssues(t *testing.T) {
 	}
 }
 
+// RFC 8555 Section 7.4: finalizing an order that is not ready MUST return
+// 403 orderNotReady, which clients treat as retriable; malformed is terminal.
 func TestFinalizeNotReady(t *testing.T) {
 	t.Parallel()
 
@@ -84,7 +87,16 @@ func TestFinalizeNotReady(t *testing.T) {
 
 	client := newACMEClient(t, ts)
 	order, _ := pendingChallenge(t, client, "pending-device")
-	if _, _, err := client.CreateOrderCert(t.Context(), order.FinalizeURL, newCSR(t), true); err == nil {
-		t.Error("CreateOrderCert() error = nil, want not-ready failure")
+	_, _, err := client.CreateOrderCert(t.Context(), order.FinalizeURL, newCSR(t), true)
+
+	var ae *acme.Error
+	if !errors.As(err, &ae) {
+		t.Fatalf("CreateOrderCert() error = %v, want *acme.Error", err)
+	}
+	if ae.StatusCode != http.StatusForbidden {
+		t.Errorf("status = %d, want %d", ae.StatusCode, http.StatusForbidden)
+	}
+	if ae.ProblemType != "urn:ietf:params:acme:error:orderNotReady" {
+		t.Errorf("problem type = %q, want orderNotReady", ae.ProblemType)
 	}
 }

--- a/handlers_flow_test.go
+++ b/handlers_flow_test.go
@@ -8,8 +8,10 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/brandonweeks/nanoca"
 	nullauthorizer "github.com/brandonweeks/nanoca/authorizers/null"
@@ -29,7 +31,14 @@ func newACMEClient(t *testing.T, ts *httptest.Server) *acme.Client {
 	if err != nil {
 		t.Fatalf("failed to generate key: %v", err)
 	}
-	client := &acme.Client{DirectoryURL: ts.URL + "/directory", HTTPClient: ts.Client(), Key: key}
+	client := &acme.Client{
+		DirectoryURL: ts.URL + "/directory",
+		HTTPClient:   ts.Client(),
+		Key:          key,
+		// The client treats every 5xx as retriable and would loop until the
+		// test context is cancelled; fail on the first response instead.
+		RetryBackoff: func(int, *http.Request, *http.Response) time.Duration { return -1 },
+	}
 	if _, err := client.Register(t.Context(), &acme.Account{}, acme.AcceptTOS); err != nil {
 		t.Fatalf("failed to register account: %v", err)
 	}

--- a/problems.go
+++ b/problems.go
@@ -16,6 +16,7 @@ const (
 	badSignatureAlgorithmErr = ACMEProblemTypePrefix + "badSignatureAlgorithm"
 	invalidContactErr        = ACMEProblemTypePrefix + "invalidContact"
 	malformedErr             = ACMEProblemTypePrefix + "malformed"
+	orderNotReadyErr         = ACMEProblemTypePrefix + "orderNotReady"
 	serverInternalErr        = ACMEProblemTypePrefix + "serverInternal"
 	unauthorizedErr          = ACMEProblemTypePrefix + "unauthorized"
 )
@@ -103,6 +104,17 @@ func InvalidContact(detail string) *Problem {
 		Type:   invalidContactErr,
 		Detail: detail,
 		Status: http.StatusBadRequest,
+	}
+}
+
+func OrderNotReady(detail string) *Problem {
+	// RFC 8555 Section 7.4: "A request to finalize an order will result in error if the order is
+	// not in the 'ready' state. In such cases, the server MUST return a 403 (Forbidden) error with
+	// a problem document of type 'orderNotReady'."
+	return &Problem{
+		Type:   orderNotReadyErr,
+		Detail: detail,
+		Status: http.StatusForbidden,
 	}
 }
 


### PR DESCRIPTION
Finalize returns real problem documents: 403 orderNotReady for a non-ready order (RFC 8555 §7.4), badCSR for an undecodable CSR, unauthorized for a foreign account, and serverInternal with the cause logged for backend failures; new-order backend failures are 500s, not 400s.