### PR TITLE
fix(handlers): reject unattestable identifier types at new-order

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -326,6 +326,16 @@ func (ca *CA) handleNewOrder(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Only attestable identifier types get a challenge in createOrder; any
+	// other type would yield an authorization with no challenges, which
+	// nothing could ever validate.
+	for _, identifier := range orderReq.Identifiers {
+		if identifier.Type != IdentifierTypePermanentIdentifier && identifier.Type != IdentifierTypeHardwareModule {
+			ca.writeProblem(ctx, w, UnsupportedIdentifier(fmt.Sprintf("Unsupported identifier type %q", identifier.Type)))
+			return
+		}
+	}
+
 	order, err := ca.createOrder(ctx, postData.accountID, orderReq)
 	if err != nil {
 		ca.writeProblem(ctx, w, InternalServerError("Failed to create order"))
@@ -891,7 +901,8 @@ func (ca *CA) updateAuthorizationStatus(ctx context.Context, authzID string) {
 		return // Final states
 	}
 
-	allValid := true
+	// An authorization with no challenges must not count as valid.
+	allValid := len(authz.Challenges) > 0
 	anyInvalid := false
 
 	for i, challenge := range authz.Challenges {

--- a/handlers_flow_test.go
+++ b/handlers_flow_test.go
@@ -233,3 +233,36 @@ func TestOrderBelongsToAnotherAccount(t *testing.T) {
 		t.Error("GetOrder() by other account error = nil, want error")
 	}
 }
+
+// createOrder builds challenges only for permanent-identifier and
+// hardware-module identifiers, so any other type yields an authorization
+// with zero challenges — an authorization that must never settle valid and
+// an order that must never be promoted, since nothing was ever validated.
+func TestZeroChallengeAuthorizationNotSettledValid(t *testing.T) {
+	t.Parallel()
+
+	ts, _ := setupTestServerWithAttestation(t, nullauthorizer.New())
+	client := newACMEClient(t, ts)
+
+	order, err := client.AuthorizeOrder(t.Context(), []acme.AuthzID{{Type: "dns", Value: "device.example"}})
+	if err != nil {
+		// Rejecting the identifier at new-order is also correct.
+		return
+	}
+
+	authz, err := client.GetAuthorization(t.Context(), order.AuthzURLs[0])
+	if err != nil {
+		t.Fatalf("GetAuthorization() error = %v", err)
+	}
+	if authz.Status == acme.StatusValid {
+		t.Errorf("authorization with no challenges polled as %q, want never valid", authz.Status)
+	}
+
+	polled, err := client.GetOrder(t.Context(), order.URI)
+	if err != nil {
+		t.Fatalf("GetOrder() error = %v", err)
+	}
+	if polled.Status == acme.StatusReady || polled.Status == acme.StatusValid {
+		t.Errorf("order status = %q, want not promoted without any validation", polled.Status)
+	}
+}

--- a/problems.go
+++ b/problems.go
@@ -19,6 +19,7 @@ const (
 	orderNotReadyErr         = ACMEProblemTypePrefix + "orderNotReady"
 	serverInternalErr        = ACMEProblemTypePrefix + "serverInternal"
 	unauthorizedErr          = ACMEProblemTypePrefix + "unauthorized"
+	unsupportedIdentifierErr = ACMEProblemTypePrefix + "unsupportedIdentifier"
 )
 
 // Problem represents an RFC 7807/9457 compliant problem details object
@@ -123,6 +124,14 @@ func Unauthorized(detail string) *Problem {
 		Type:   unauthorizedErr,
 		Detail: detail,
 		Status: http.StatusForbidden,
+	}
+}
+
+func UnsupportedIdentifier(detail string) *Problem {
+	return &Problem{
+		Type:   unsupportedIdentifierErr,
+		Detail: detail,
+		Status: http.StatusBadRequest,
 	}
 }
 


### PR DESCRIPTION
createOrder only builds device-attest-01 challenges for permanent-identifier and hardware-module identifiers; any other type produced an authorization with no challenges. Refuse those orders with unsupportedIdentifier, and never let an empty authorization read as all-valid.