### PR TITLE
fix(handlers): treat a nil DeviceInfo as a failed attestation

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -797,6 +797,25 @@ func (ca *CA) handleChallengeResponse(ctx context.Context, w http.ResponseWriter
 		return
 	}
 
+	// A validation that proves no identity must not settle valid: the
+	// DeviceInfo is what authorization and the certificate's SANs are
+	// built from.
+	if deviceInfo == nil {
+		ca.logger.ErrorContext(ctx, "Attestation verifier returned no device identity", "challenge_id", challenge.ID, "format", attObj.Format)
+
+		now := time.Now()
+		prob := Unauthorized("Attestation yielded no device identity")
+
+		if updateErr := ca.storage.SetChallengeInvalid(ctx, challenge.ID, now, prob); updateErr != nil {
+			ca.logger.ErrorContext(ctx, "Failed to update challenge status after empty verification", "error", updateErr)
+		}
+
+		ca.updateAuthorizationStatus(ctx, challenge.AuthzID)
+
+		ca.writeProblem(ctx, w, prob)
+		return
+	}
+
 	authorized, err := ca.authorizer.Authorize(ctx, deviceInfo)
 	if err != nil {
 		ca.logger.ErrorContext(ctx, "Device authorization check failed", "challenge_id", challenge.ID, "error", err)

--- a/handlers_verifier_test.go
+++ b/handlers_verifier_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"errors"
+	"net/http"
 	"testing"
 
 	"github.com/brandonweeks/nanoca"
@@ -42,5 +43,39 @@ func TestChallengeVerifierFailure(t *testing.T) {
 	}
 	if authz.Status != acme.StatusInvalid {
 		t.Errorf("authorization status = %q, want invalid", authz.Status)
+	}
+}
+
+type nilDeviceInfoVerifier struct{}
+
+func (nilDeviceInfoVerifier) Format() string { return "nildev" }
+
+func (nilDeviceInfoVerifier) Verify(context.Context, nanoca.AttestationStatement, []byte) (*nanoca.DeviceInfo, error) {
+	return nil, nil
+}
+
+// A verifier that returns no identity leaves finalize nothing to build the
+// certificate's SANs from, so the challenge must fail rather than settle
+// valid and wedge the order.
+func TestChallengeNilDeviceInfoRejected(t *testing.T) {
+	t.Parallel()
+
+	ts, _ := newTestServer(t, nullauthorizer.New(), nil, nil, nilDeviceInfoVerifier{})
+	client := newACMEClient(t, ts)
+
+	_, chal := pendingChallenge(t, client, "nil-identity-device")
+
+	attObj, err := cbor.Marshal(map[string]any{"fmt": "nildev", "attStmt": map[string]any{}})
+	if err != nil {
+		t.Fatalf("failed to marshal attestation: %v", err)
+	}
+	err = submitAttObj(t, client, chal, base64.RawURLEncoding.EncodeToString(attObj))
+	if err == nil {
+		t.Fatal("Accept() error = nil, want rejection of identity-less attestation")
+	}
+
+	var ae *acme.Error
+	if errors.As(err, &ae) && ae.StatusCode >= http.StatusInternalServerError {
+		t.Errorf("challenge POST status = %d, want non-5xx rejection", ae.StatusCode)
 	}
 }

--- a/interfaces.go
+++ b/interfaces.go
@@ -7,6 +7,9 @@ import (
 
 type AttestationVerifier interface {
 	Format() string
+	// Verify returns the device identity the statement proves; the identity
+	// is what authorization and the certificate's SANs are built from, so a
+	// nil DeviceInfo with a nil error is treated as a failed attestation.
 	Verify(ctx context.Context, stmt AttestationStatement, challenge []byte) (*DeviceInfo, error)
 }
 


### PR DESCRIPTION
The AttestationVerifier contract never promised a non-nil DeviceInfo, and a challenge validated without one settles valid but leaves finalize nothing to derive the certificate's SANs from, wedging the order. Fail the challenge instead and document the contract.