### PR TITLE
fix(handlers): keep attestation objects out of authz records and responses

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"slices"
 	"strings"
 	"time"
 
@@ -556,9 +557,29 @@ func (ca *CA) handleCertificate(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// scrubStorageState strips storage-internal state — the stored attestation
+// object — from a client-facing copy; the ACME wire format has no such
+// field.
+func scrubStorageState(data any) any {
+	switch v := data.(type) {
+	case *Challenge:
+		scrubbed := *v
+		scrubbed.Attestation = nil
+		return &scrubbed
+	case *Authorization:
+		scrubbed := *v
+		scrubbed.Challenges = slices.Clone(v.Challenges)
+		for i := range scrubbed.Challenges {
+			scrubbed.Challenges[i].Attestation = nil
+		}
+		return &scrubbed
+	}
+	return data
+}
+
 func (ca *CA) writeJSONResponse(ctx context.Context, w http.ResponseWriter, statusCode int, data any, nonce string) {
 	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(data); err != nil {
+	if err := json.NewEncoder(&buf).Encode(scrubStorageState(data)); err != nil {
 		ca.writeProblem(ctx, w, InternalServerError("Failed to encode response"))
 		return
 	}
@@ -931,6 +952,10 @@ func (ca *CA) updateAuthorizationStatus(ctx context.Context, authzID string) {
 			continue
 		}
 
+		// The attestation blob belongs to the challenge record: finalize
+		// re-reads it there, so an embedded copy is dead weight persisted
+		// with every settled authorization.
+		currentChallenge.Attestation = nil
 		authz.Challenges[i] = *currentChallenge
 
 		if currentChallenge.Status == "invalid" {

--- a/handlers_internal_test.go
+++ b/handlers_internal_test.go
@@ -1,0 +1,37 @@
+package nanoca
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// The stored attestation object is a storage concern; it must never reach
+// the ACME wire format, and scrubbing it must not mutate the stored
+// record's copy.
+func TestWriteJSONResponseScrubsStorageState(t *testing.T) {
+	t.Parallel()
+
+	ca := &CA{logger: slog.New(slog.DiscardHandler)}
+	attestation := map[string]any{"fmt": "apple", "x5c": "leaf"}
+
+	challenge := &Challenge{ID: "c1", Status: ChallengeStatusValid, Attestation: attestation}
+	authz := &Authorization{ID: "a1", Challenges: []Challenge{{ID: "c1", Attestation: attestation}}}
+
+	for name, data := range map[string]any{
+		"challenge":     challenge,
+		"authorization": authz,
+	} {
+		rec := httptest.NewRecorder()
+		ca.writeJSONResponse(t.Context(), rec, http.StatusOK, data, "")
+		if body := rec.Body.String(); strings.Contains(body, "attestation") {
+			t.Errorf("%s response leaks attestation state:\n%s", name, body)
+		}
+	}
+
+	if challenge.Attestation == nil || authz.Challenges[0].Attestation == nil {
+		t.Error("scrubbing mutated the caller's records")
+	}
+}


### PR DESCRIPTION
The stored attestation is only read back from the challenge record at finalize, yet it was persisted again inside every settled authorization's embedded challenge copies and served verbatim in challenge and authorization responses. Scrub it from the wire and stop embedding it.