### PR TITLE
fix(storage): delete expired nonces on consumption

### DIFF
--- a/storage/badger/errors_test.go
+++ b/storage/badger/errors_test.go
@@ -74,6 +74,11 @@ func TestConsumeNonceErrors(t *testing.T) {
 	if _, err := s.ConsumeNonce(ctx, "n1", -time.Second); !errors.Is(err, nanoca.ErrNonceExpired) {
 		t.Errorf("ConsumeNonce(expired) error = %v, want ErrNonceExpired", err)
 	}
+	// Consuming an expired nonce must still remove it, or expired nonces
+	// accumulate forever (nonce keys carry no TTL).
+	if _, err := s.ConsumeNonce(ctx, "n1", -time.Second); !errors.Is(err, nanoca.ErrNonceNotFound) {
+		t.Errorf("ConsumeNonce(expired, again) error = %v, want ErrNonceNotFound", err)
+	}
 }
 
 func TestChallengeStatusMismatch(t *testing.T) {

--- a/storage/badger/storage.go
+++ b/storage/badger/storage.go
@@ -109,17 +109,17 @@ func (s *Storage) ConsumeNonce(_ context.Context, value string, expiry time.Dura
 			return fmt.Errorf("failed to unmarshal nonce: %w", err)
 		}
 
-		if time.Since(nonce.CreatedAt) > expiry {
-			if err := txn.Delete(nonceKey(value)); err != nil {
-				return fmt.Errorf("failed to delete expired nonce: %w", err)
-			}
-			return nanoca.ErrNonceExpired
-		}
-
 		return txn.Delete(nonceKey(value))
 	})
 	if err != nil {
 		return nil, err
+	}
+
+	// Expiry is reported only after the transaction commits: returning the
+	// error from inside it would roll back the delete and keep the expired
+	// nonce forever (nonce keys carry no TTL).
+	if time.Since(nonce.CreatedAt) > expiry {
+		return nil, nanoca.ErrNonceExpired
 	}
 
 	return &nonce, nil


### PR DESCRIPTION
Reporting expiry from inside the write transaction rolled back the delete, so expired nonces accumulated forever; report it after the commit instead.