### PR TITLE
fix(handlers): settle order state and ownership before the CSR at finalize

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -1095,11 +1095,11 @@ func (ca *CA) updateAuthorizationStatus(ctx context.Context, authz *Authorizatio
 	}
 }
 
-func (ca *CA) finalizeCertificate(ctx context.Context, orderID, accountID string, csrB64 string) (*Order, error) {
-	// Decode base64url-encoded CSR DER
-	// RFC 8555 Section 7.4: "csr (required, string): A CSR encoding the parameters for the
-	// certificate being requested [RFC2986]. The CSR is sent in the
-	// base64url-encoded version of the DER format."
+// parseFinalizeCSR decodes and validates the CSR from a finalize request.
+// RFC 8555 Section 7.4: "csr (required, string): A CSR encoding the parameters for the
+// certificate being requested [RFC2986]. The CSR is sent in the
+// base64url-encoded version of the DER format."
+func parseFinalizeCSR(csrB64 string) (*x509.CertificateRequest, error) {
 	csrDER, err := base64.RawURLEncoding.DecodeString(csrB64)
 	if err != nil {
 		return nil, BadCSR("Invalid CSR base64url encoding")
@@ -1114,6 +1114,10 @@ func (ca *CA) finalizeCertificate(ctx context.Context, orderID, accountID string
 		return nil, BadCSR(fmt.Sprintf("CSR signature verification failed: %s", err.Error()))
 	}
 
+	return csr, nil
+}
+
+func (ca *CA) finalizeCertificate(ctx context.Context, orderID, accountID string, csrB64 string) (*Order, error) {
 	// Existence and ownership are settled before the reservation is taken,
 	// so a request that has no claim on the order can never hold its lock.
 	order, err := ca.storage.GetOrder(ctx, orderID)
@@ -1141,6 +1145,14 @@ func (ca *CA) finalizeCertificate(ctx context.Context, orderID, accountID string
 			return nil, lookupProblem(err, "Order")
 		}
 		return nil, fmt.Errorf("failed to reserve order for finalization: %w", err)
+	}
+
+	// RFC 8555 Section 7.4 conditions the orderNotReady error only on order
+	// state, so the CSR is judged after the reserve has settled state and
+	// ownership; a rejected CSR then releases the reservation back to ready.
+	csr, err := parseFinalizeCSR(csrB64)
+	if err != nil {
+		return nil, ca.failOrder(ctx, orderID, token, err)
 	}
 
 	cert, deviceInfos, err := ca.issueForOrder(ctx, order, csr, token)
@@ -1230,11 +1242,13 @@ func (ca *CA) issueForOrder(ctx context.Context, order *Order, csr *x509.Certifi
 // failOrder releases the finalize reservation, distinguishing terminal
 // failures from transient ones. A client-fault problem can only recur on
 // retry, so the order moves to invalid per RFC 8555 Section 7.1.6 and the
-// client abandons it; anything else returns the order to ready so a retry
-// can finalize again.
+// client abandons it. badCSR is the exception: only the CSR is at fault,
+// and Section 7.4 has the order stay ready so an amended CSR can finalize
+// it. Anything else returns the order to ready so a retry can finalize
+// again.
 func (ca *CA) failOrder(ctx context.Context, orderID, token string, err error) error {
 	to := OrderStatusReady
-	if prob, ok := errors.AsType[*Problem](err); ok && prob.Status < http.StatusInternalServerError {
+	if prob, ok := errors.AsType[*Problem](err); ok && prob.Status < http.StatusInternalServerError && prob.Type != badCSRErr {
 		to = OrderStatusInvalid
 	}
 	switch serr := ca.storage.ReleaseOrderFinalize(ctx, orderID, token, to); {

--- a/handlers_finalize_test.go
+++ b/handlers_finalize_test.go
@@ -117,6 +117,73 @@ func TestFinalizeObserverErrorStillIssues(t *testing.T) {
 	}
 }
 
+// RFC 8555 Section 7.4 conditions the orderNotReady MUST only on order
+// state, so it takes precedence over CSR validation: a client whose CSR is
+// also broken must still learn the order isn't ready, not get a terminal
+// badCSR for an order that may yet become finalizable.
+func TestFinalizeNotReadyBadCSR(t *testing.T) {
+	t.Parallel()
+
+	ts, _ := setupTestServerWithAttestation(t, nullauthorizer.New())
+
+	client := newACMEClient(t, ts)
+	order, _ := pendingChallenge(t, client, "pending-bad-csr-device")
+	_, _, err := client.CreateOrderCert(t.Context(), order.FinalizeURL, []byte("not a csr"), true)
+
+	var ae *acme.Error
+	if !errors.As(err, &ae) {
+		t.Fatalf("CreateOrderCert() error = %v, want *acme.Error", err)
+	}
+	if ae.ProblemType != "urn:ietf:params:acme:error:orderNotReady" {
+		t.Errorf("problem type = %q, want orderNotReady", ae.ProblemType)
+	}
+}
+
+// Ownership is judged before the CSR: a foreign account probing another
+// account's finalize URL gets unauthorized, not CSR-validation feedback.
+func TestFinalizeForeignOrder(t *testing.T) {
+	t.Parallel()
+
+	ts, _ := setupTestServerWithAttestation(t, nullauthorizer.New())
+
+	owner := newACMEClient(t, ts)
+	order, _ := pendingChallenge(t, owner, "owned-finalize-device")
+
+	other := newACMEClient(t, ts)
+	_, _, err := other.CreateOrderCert(t.Context(), order.FinalizeURL, []byte("not a csr"), true)
+
+	var ae *acme.Error
+	if !errors.As(err, &ae) {
+		t.Fatalf("CreateOrderCert() error = %v, want *acme.Error", err)
+	}
+	if ae.ProblemType != "urn:ietf:params:acme:error:unauthorized" {
+		t.Errorf("problem type = %q, want unauthorized", ae.ProblemType)
+	}
+}
+
+// RFC 8555 Section 7.4: after badCSR the order SHOULD stay in "ready" so
+// the client can submit a new finalize request with an amended CSR.
+func TestFinalizeBadCSRLeavesOrderReady(t *testing.T) {
+	t.Parallel()
+
+	ts, _ := newTestServer(t, testServerConfig{})
+
+	client, order := driveToReady(t, ts)
+
+	_, _, err := client.CreateOrderCert(t.Context(), order.FinalizeURL, []byte("not a csr"), true)
+	var ae *acme.Error
+	if !errors.As(err, &ae) {
+		t.Fatalf("CreateOrderCert() error = %v, want *acme.Error", err)
+	}
+	if ae.ProblemType != "urn:ietf:params:acme:error:badCSR" {
+		t.Errorf("problem type = %q, want badCSR", ae.ProblemType)
+	}
+
+	if _, _, err := client.CreateOrderCert(t.Context(), order.FinalizeURL, newCSR(t), true); err != nil {
+		t.Fatalf("CreateOrderCert() with amended CSR error = %v, want success", err)
+	}
+}
+
 // RFC 8555 Section 7.4: finalizing an order that is not ready MUST return
 // 403 orderNotReady, which clients treat as retriable; malformed is terminal.
 func TestFinalizeNotReady(t *testing.T) {

--- a/handlers_flow_test.go
+++ b/handlers_flow_test.go
@@ -227,22 +227,6 @@ func TestNotFoundLookups(t *testing.T) {
 	}
 }
 
-func TestFinalizeBadCSR(t *testing.T) {
-	t.Parallel()
-
-	ts, _ := setupTestServerWithAttestation(t, nullauthorizer.New())
-	client := newACMEClient(t, ts)
-
-	order, chal := pendingChallenge(t, client, "finalize-device")
-	if err := submitAttObj(t, client, chal, nullAttObj(t)); err != nil {
-		t.Fatalf("failed to accept challenge: %v", err)
-	}
-
-	if _, _, err := client.CreateOrderCert(t.Context(), order.FinalizeURL, []byte("not a valid csr"), true); err == nil {
-		t.Error("CreateOrderCert() error = nil, want error")
-	}
-}
-
 func TestOrderBelongsToAnotherAccount(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
RFC 8555 §7.4 conditions orderNotReady only on order state, so finalize now loads the order, checks ownership, and takes the reservation before touching the CSR: a non-ready order returns 403 orderNotReady and a foreign account gets unauthorized regardless of CSR validity. A rejected CSR releases the reservation back to ready per §7.4, so the client can finalize again with an amended CSR.