### PR TITLE
fix(handlers): carry the cause of 500 responses into the problem log

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -40,7 +40,7 @@ func lookupProblem(err error, resource string) *Problem {
 	if errors.Is(err, ErrNotFound) {
 		return Malformed(resource + " not found")
 	}
-	return InternalServerError("Failed to get " + strings.ToLower(resource))
+	return InternalServerError("Failed to get " + strings.ToLower(resource)).WithCause(err)
 }
 
 // isFenceRejection reports whether a guarded or fenced storage write was
@@ -88,7 +88,7 @@ func (ca *CA) handleNewNonce(w http.ResponseWriter, r *http.Request) {
 
 	nonce, err := ca.generateNonce(ctx)
 	if err != nil {
-		ca.writeProblem(ctx, w, InternalServerError("Failed to generate nonce"))
+		ca.writeProblem(ctx, w, InternalServerError("Failed to generate nonce").WithCause(err))
 		return
 	}
 
@@ -123,13 +123,13 @@ func (ca *CA) handleNewAccount(w http.ResponseWriter, r *http.Request) {
 
 	keyThumbprint, err := jwkThumbprint(postData.jwk)
 	if err != nil {
-		ca.writeProblem(ctx, w, InternalServerError("Failed to process key"))
+		ca.writeProblem(ctx, w, InternalServerError("Failed to process key").WithCause(err))
 		return
 	}
 
 	existingAccount, err := ca.storage.GetAccountByKey(ctx, keyThumbprint)
 	if err != nil && !errors.Is(err, ErrNotFound) {
-		ca.writeProblem(ctx, w, InternalServerError("Failed to look up account"))
+		ca.writeProblem(ctx, w, InternalServerError("Failed to look up account").WithCause(err))
 		return
 	}
 	if err == nil {
@@ -276,7 +276,7 @@ func (ca *CA) verifyPOST(r *http.Request, kx keyExtractor) (*authenticatedPOST, 
 		if _, ok := errors.AsType[*http.MaxBytesError](err); ok {
 			return nil, RequestTooLarge("Request body too large")
 		}
-		return nil, InternalServerError("Failed to read request body")
+		return nil, InternalServerError("Failed to read request body").WithCause(err)
 	}
 
 	if len(bodyBytes) == 0 {
@@ -349,7 +349,7 @@ func (ca *CA) handleNewOrder(w http.ResponseWriter, r *http.Request) {
 
 	order, err := ca.createOrder(ctx, postData.accountID, orderReq)
 	if err != nil {
-		ca.writeProblem(ctx, w, InternalServerError("Failed to create order"))
+		ca.writeProblem(ctx, w, InternalServerError("Failed to create order").WithCause(err))
 		return
 	}
 	ctx = WithOrderID(ctx, order.ID)
@@ -433,10 +433,7 @@ func (ca *CA) handleOrderFinalize(ctx context.Context, w http.ResponseWriter, or
 		if prob, ok := errors.AsType[*Problem](err); ok {
 			ca.writeProblem(ctx, w, prob)
 		} else {
-			// writeProblem logs only the generic detail; without this line
-			// the cause of the 500 is lost.
-			ca.logger.ErrorContext(ctx, "Failed to finalize certificate", "error", err)
-			ca.writeProblem(ctx, w, InternalServerError("Failed to finalize certificate"))
+			ca.writeProblem(ctx, w, InternalServerError("Failed to finalize certificate").WithCause(err))
 		}
 		return
 	}
@@ -509,7 +506,7 @@ func (ca *CA) handleChallenge(w http.ResponseWriter, r *http.Request) {
 
 	authz, err := ca.storage.GetAuthorization(ctx, challenge.AuthzID)
 	if err != nil {
-		ca.writeProblem(ctx, w, InternalServerError("Failed to get authorization for challenge"))
+		ca.writeProblem(ctx, w, InternalServerError("Failed to get authorization for challenge").WithCause(err))
 		return
 	}
 	ctx = WithOrderID(ctx, authz.OrderID)
@@ -575,7 +572,7 @@ func (ca *CA) handleCertificate(w http.ResponseWriter, r *http.Request) {
 
 	orders, err := ca.storage.GetOrdersByAccount(ctx, postData.accountID)
 	if err != nil {
-		ca.writeProblem(ctx, w, InternalServerError("Failed to get orders"))
+		ca.writeProblem(ctx, w, InternalServerError("Failed to get orders").WithCause(err))
 		return
 	}
 
@@ -595,7 +592,7 @@ func (ca *CA) handleCertificate(w http.ResponseWriter, r *http.Request) {
 
 	nonce, err := ca.generateNonce(ctx)
 	if err != nil {
-		ca.writeProblem(ctx, w, InternalServerError("Failed to generate nonce"))
+		ca.writeProblem(ctx, w, InternalServerError("Failed to generate nonce").WithCause(err))
 		return
 	}
 
@@ -640,7 +637,7 @@ func scrubStorageState(data any) any {
 func (ca *CA) writeJSONResponse(ctx context.Context, w http.ResponseWriter, statusCode int, data any, nonce string) {
 	var buf bytes.Buffer
 	if err := json.NewEncoder(&buf).Encode(scrubStorageState(data)); err != nil {
-		ca.writeProblem(ctx, w, InternalServerError("Failed to encode response"))
+		ca.writeProblem(ctx, w, InternalServerError("Failed to encode response").WithCause(err))
 		return
 	}
 
@@ -658,17 +655,21 @@ func (ca *CA) writeJSONResponse(ctx context.Context, w http.ResponseWriter, stat
 func (ca *CA) writeJSONResponseWithNonce(ctx context.Context, w http.ResponseWriter, statusCode int, data any) {
 	nonce, err := ca.generateNonce(ctx)
 	if err != nil {
-		ca.writeProblem(ctx, w, InternalServerError("Failed to generate nonce"))
+		ca.writeProblem(ctx, w, InternalServerError("Failed to generate nonce").WithCause(err))
 		return
 	}
 	ca.writeJSONResponse(ctx, w, statusCode, data, nonce)
 }
 
 func (ca *CA) writeProblem(ctx context.Context, w http.ResponseWriter, prob *Problem) {
+	attrs := []any{"status", prob.Status, "type", prob.Type, "detail", prob.Detail}
+	if prob.Cause != nil {
+		attrs = append(attrs, "error", prob.Cause)
+	}
 	if prob.Status >= 500 {
-		ca.logger.ErrorContext(ctx, "Server error", "status", prob.Status, "type", prob.Type, "detail", prob.Detail)
+		ca.logger.ErrorContext(ctx, "Server error", attrs...)
 	} else {
-		ca.logger.WarnContext(ctx, "Client error", "status", prob.Status, "type", prob.Type, "detail", prob.Detail)
+		ca.logger.WarnContext(ctx, "Client error", attrs...)
 	}
 
 	// RFC 8555 Section 6.5: "The server MUST include a Replay-Nonce header field in every
@@ -931,8 +932,7 @@ func (ca *CA) handleChallengeResponse(ctx context.Context, w http.ResponseWriter
 
 	challenge, err = ca.storage.GetChallenge(ctx, challenge.ID)
 	if err != nil {
-		ca.logger.ErrorContext(ctx, "Failed to re-fetch challenge after validation", "error", err)
-		ca.writeProblem(ctx, w, InternalServerError("Failed to retrieve challenge"))
+		ca.writeProblem(ctx, w, InternalServerError("Failed to retrieve challenge after validation").WithCause(err))
 		return
 	}
 	ca.writeJSONResponseWithNonce(ctx, w, http.StatusOK, challenge)
@@ -943,8 +943,7 @@ func (ca *CA) handleChallengeResponse(ctx context.Context, w http.ResponseWriter
 func (ca *CA) reportChallengeState(ctx context.Context, w http.ResponseWriter, challengeID string) {
 	current, err := ca.storage.GetChallenge(ctx, challengeID)
 	if err != nil {
-		ca.logger.ErrorContext(ctx, "Failed to get challenge after lost validation race", "error", err)
-		ca.writeProblem(ctx, w, InternalServerError("Failed to get challenge"))
+		ca.writeProblem(ctx, w, InternalServerError("Failed to get challenge after lost validation race").WithCause(err))
 		return
 	}
 	ca.writeJSONResponseWithNonce(ctx, w, http.StatusOK, current)

--- a/handlers_finalize_test.go
+++ b/handlers_finalize_test.go
@@ -100,6 +100,9 @@ func TestFinalizeIssuerErrorLogged(t *testing.T) {
 	if !strings.Contains(logs.String(), "issuer unavailable") {
 		t.Errorf("finalize failure logs omit the issuer error %q:\n%s", "issuer unavailable", logs.String())
 	}
+	if got := strings.Count(logs.String(), "level=ERROR"); got != 1 {
+		t.Errorf("finalize failure produced %d error records, want 1:\n%s", got, logs.String())
+	}
 }
 
 func TestFinalizeObserverErrorStillIssues(t *testing.T) {

--- a/handlers_storage_test.go
+++ b/handlers_storage_test.go
@@ -269,6 +269,59 @@ func TestNewOrderStorageFailure(t *testing.T) {
 	wantServerInternal(t, err)
 }
 
+// The client only ever sees the generic serverInternal detail, so the
+// backend error has to reach the server log or the 500 cannot be debugged.
+func TestNewOrderStorageFailureLogged(t *testing.T) {
+	t.Parallel()
+
+	var logs syncBuffer
+	ts, _ := newTestServer(t, testServerConfig{
+		logger:  slog.New(slog.NewTextHandler(&logs, nil)),
+		storage: orderCreateFailingStorage{Storage: newTestStorage(t)},
+		issuer:  stubIssuer{},
+	})
+
+	client := newUnregisteredClient(t, ts)
+	if _, err := client.Register(t.Context(), &acme.Account{}, acme.AcceptTOS); err != nil {
+		t.Fatalf("failed to register account: %v", err)
+	}
+	if _, err := client.AuthorizeOrder(t.Context(), []acme.AuthzID{{Type: "permanent-identifier", Value: "device"}}); err == nil {
+		t.Fatal("AuthorizeOrder() error = nil, want storage failure")
+	}
+
+	if !strings.Contains(logs.String(), "backend unavailable") {
+		t.Errorf("new-order failure logs omit the storage error %q:\n%s", "backend unavailable", logs.String())
+	}
+}
+
+func TestFinalizeStorageFailureLogged(t *testing.T) {
+	t.Parallel()
+
+	var logs syncBuffer
+	ts, _ := newTestServer(t, testServerConfig{
+		logger:  slog.New(slog.NewTextHandler(&logs, nil)),
+		storage: orderLookupFailingStorage{Storage: newTestStorage(t)},
+		issuer:  stubIssuer{},
+	})
+
+	client := newUnregisteredClient(t, ts)
+	if _, err := client.Register(t.Context(), &acme.Account{}, acme.AcceptTOS); err != nil {
+		t.Fatalf("failed to register account: %v", err)
+	}
+	order, err := client.AuthorizeOrder(t.Context(), []acme.AuthzID{{Type: "permanent-identifier", Value: "device"}})
+	if err != nil {
+		t.Fatalf("failed to create order: %v", err)
+	}
+
+	if _, _, err := client.CreateOrderCert(t.Context(), order.FinalizeURL, newCSR(t), true); err == nil {
+		t.Fatal("CreateOrderCert() error = nil, want storage failure")
+	}
+
+	if !strings.Contains(logs.String(), "backend unavailable") {
+		t.Errorf("finalize failure logs omit the storage error %q:\n%s", "backend unavailable", logs.String())
+	}
+}
+
 // An ErrNotFound wrapped out of CreateOrder is a backend failure, not proof
 // the account is gone: accountDoesNotExist makes clients discard their
 // registration and re-enroll.

--- a/problems.go
+++ b/problems.go
@@ -49,10 +49,19 @@ type Problem struct {
 	// RFC 8555 Section 6.2: "The problem document returned with the error MUST include an
 	// 'algorithms' field with an array of supported 'alg' values."
 	Algorithms []string `json:"algorithms,omitempty"`
+
+	// Cause is the underlying server-side error. It is logged alongside the
+	// problem but never serialized to the client.
+	Cause error `json:"-"`
 }
 
 func (p *Problem) Error() string {
 	return fmt.Sprintf("%s :: %s", p.Type, p.Detail)
+}
+
+func (p *Problem) WithCause(err error) *Problem {
+	p.Cause = err
+	return p
 }
 
 func InternalServerError(detail string) *Problem {


### PR DESCRIPTION
Problem gains a Cause field that writeProblem logs but never serializes, so every serverInternal response records its underlying error exactly once. Previously the cause was dropped entirely at most sites (new-order, storage lookups, nonce generation) and double-logged at finalize.