### PR TITLE
fix(storage): mark the order valid inside CompleteOrder

### DIFF
--- a/storage/badger/storage.go
+++ b/storage/badger/storage.go
@@ -506,7 +506,11 @@ func (s *Storage) ReleaseChallengeValidation(_ context.Context, id, reservationT
 }
 
 func (s *Storage) CompleteOrder(_ context.Context, order *nanoca.Order, cert *nanoca.Certificate, token string) error {
+	// CompleteOrder owns the processing-to-valid transition; forcing the
+	// status here keeps a stored certificate from ever sharing a record
+	// with a non-valid order, whatever the caller passed.
 	completed := *order
+	completed.Status = nanoca.OrderStatusValid
 	completed.Reservation = nil
 
 	return s.update(func(txn *badger.Txn) error {

--- a/storage/badger/storage_test.go
+++ b/storage/badger/storage_test.go
@@ -606,7 +606,9 @@ func TestStorage_CompleteOrder(t *testing.T) {
 	if err := storage.CreateOrder(ctx, &nanoca.Order{ID: "o1", Status: nanoca.OrderStatusPending}); err != nil {
 		t.Fatalf("CreateOrder() error = %v", err)
 	}
-	order := &nanoca.Order{ID: "o1", Status: nanoca.OrderStatusValid}
+	// Deliberately not pre-set to valid: CompleteOrder owns the
+	// processing-to-valid transition.
+	order := &nanoca.Order{ID: "o1", Status: nanoca.OrderStatusProcessing}
 	cert := &nanoca.Certificate{ID: "o1", SerialNumber: "1"}
 
 	// Completion requires a reserved (processing) order.


### PR DESCRIPTION
The interface makes CompleteOrder itself perform the processing-to-valid transition; relying on the caller to pre-set the status lets a future caller commit a certificate against a processing order that reserve() would reclaim. Force the status inside the transaction.