### PR TITLE
refactor: drop the fencing terminology

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -43,11 +43,11 @@ func lookupProblem(err error, resource string) *Problem {
 	return InternalServerError("Failed to get " + strings.ToLower(resource)).WithCause(err)
 }
 
-// isFenceRejection reports whether a guarded or fenced storage write was
+// lostRace reports whether a conditional storage write was
 // rejected because another request has settled the record; the winner's
 // result stands. Missing either sentinel would misread a lost race as a
 // backend failure.
-func isFenceRejection(err error) bool {
+func lostRace(err error) bool {
 	return errors.Is(err, ErrReserved) || errors.Is(err, ErrStatusMismatch)
 }
 
@@ -862,7 +862,7 @@ func (ca *CA) handleChallengeResponse(ctx context.Context, w http.ResponseWriter
 	// a retry once the lease lapses.
 	reservationToken := randomID(16)
 	if err := ca.storage.ReserveChallengeValidation(ctx, challenge.ID, reservationToken, ca.reservationLease); err != nil {
-		if isFenceRejection(err) {
+		if lostRace(err) {
 			ca.reportChallengeState(ctx, w, challenge.ID)
 			return
 		}
@@ -894,10 +894,10 @@ func (ca *CA) handleChallengeResponse(ctx context.Context, w http.ResponseWriter
 		// the attestation; surrender the reservation so a retry can
 		// validate once it clears, instead of invalidating the challenge.
 		if releaseErr := ca.storage.ReleaseChallengeValidation(ctx, challenge.ID, reservationToken); releaseErr != nil {
-			// A fencing rejection means another request settled the
+			// A lost race means another request settled the
 			// challenge; its result stands. Anything else leaves the
 			// challenge processing, and it heals by lease expiry.
-			if !isFenceRejection(releaseErr) {
+			if !lostRace(releaseErr) {
 				ca.logger.ErrorContext(ctx, "Failed to release challenge after authorization error", "error", releaseErr)
 			}
 		}
@@ -915,7 +915,7 @@ func (ca *CA) handleChallengeResponse(ctx context.Context, w http.ResponseWriter
 	now := time.Now()
 	if err := ca.storage.SetChallengeValid(ctx, challenge.ID, reservationToken, now, attObjBytes); err != nil {
 		// Another writer settled the challenge first; report its result.
-		if isFenceRejection(err) {
+		if lostRace(err) {
 			ca.reportChallengeState(ctx, w, challenge.ID)
 			return
 		}
@@ -954,11 +954,11 @@ func (ca *CA) reportChallengeState(ctx context.Context, w http.ResponseWriter, c
 }
 
 // failChallenge settles a reserved challenge as invalid and reports prob. A
-// fencing rejection means another request settled the challenge first: its
+// lost race means another request settled the challenge first: its
 // result is reported instead and the recompute is left to it.
 func (ca *CA) failChallenge(ctx context.Context, w http.ResponseWriter, challenge *Challenge, reservationToken string, prob *Problem) {
 	if err := ca.storage.SetChallengeInvalid(ctx, challenge.ID, reservationToken, time.Now(), prob); err != nil {
-		if isFenceRejection(err) {
+		if lostRace(err) {
 			ca.reportChallengeState(ctx, w, challenge.ID)
 			return
 		}
@@ -1231,12 +1231,12 @@ func (ca *CA) issueForOrder(ctx context.Context, order *Order, csr *x509.Certifi
 	order.Reservation = nil
 	if err := ca.storage.CompleteOrder(ctx, order, cert, token); err != nil {
 		ca.logger.ErrorContext(ctx, "Discarding signed certificate after failed completion", "serial_number", cert.SerialNumber, "error", err)
-		// A fencing rejection means the lease lapsed and another finalize
+		// A lost race means the lease lapsed and another finalize
 		// reclaimed the order; its outcome stands and there is no
 		// reservation left to release. That is a client-state condition
 		// like losing the reserve itself, not a backend failure: a 5xx
 		// would invite a retry of a finalize that has been superseded.
-		if isFenceRejection(err) {
+		if lostRace(err) {
 			return nil, nil, OrderNotReady("Order finalization was superseded by another request")
 		}
 		return nil, nil, ca.failOrder(ctx, order.ID, token, fmt.Errorf("failed to complete order: %w", err))
@@ -1259,7 +1259,7 @@ func (ca *CA) failOrder(ctx context.Context, orderID, token string, err error) e
 	}
 	switch serr := ca.storage.ReleaseOrderFinalize(ctx, orderID, token, to); {
 	case serr == nil:
-	case isFenceRejection(serr):
+	case lostRace(serr):
 		// The lease lapsed and another finalize took over; its outcome
 		// stands.
 		ca.logger.DebugContext(ctx, "Finalize reservation was reclaimed", "error", serr)

--- a/handlers_recovery_test.go
+++ b/handlers_recovery_test.go
@@ -89,7 +89,7 @@ func (s *authzWriteParkingStorage) SettleAuthorization(ctx context.Context, auth
 	return s.Storage.SettleAuthorization(ctx, authz)
 }
 
-// A zombie validation whose fenced SetChallengeInvalid is rejected has no
+// A zombie validation whose SetChallengeInvalid write is rejected has no
 // claim left on the challenge, yet it still recomputes the authorization.
 // Its stale write must not revert an authorization a reclaiming retry has
 // settled valid: with the order already ready, a reverted authorization is
@@ -133,9 +133,9 @@ func TestZombieInvalidationDoesNotRevertSettledAuthz(t *testing.T) {
 	<-verifier.entered[1]
 
 	// The zombie fails verification while the retry holds the reservation,
-	// so its fenced SetChallengeInvalid is rejected. If it goes on to
+	// so its SetChallengeInvalid write is rejected. If it goes on to
 	// recompute the authorization anyway, its stale write parks; if it
-	// stops at the fencing rejection, it finishes without writing.
+	// stops at the rejected write, it finishes without writing.
 	storage.park(1)
 	close(verifier.release[0])
 	var gate chan struct{}
@@ -342,7 +342,7 @@ func TestOrderReadyRetriesAfterStatusWriteFailure(t *testing.T) {
 }
 
 // challengeInvalidFailingStorage fails SetChallengeInvalid with a plain
-// backend error while armed, so failChallenge takes its non-fencing branch
+// backend error while armed, so failChallenge takes its backend-error branch
 // and never learns another request has claimed the challenge.
 type challengeInvalidFailingStorage struct {
 	nanoca.Storage
@@ -366,11 +366,11 @@ func (s *challengeInvalidFailingStorage) SetChallengeInvalid(ctx context.Context
 	return s.Storage.SetChallengeInvalid(ctx, id, reservationToken, validated, problem)
 }
 
-// A zombie can also lose its claim without being told: when its fenced
-// SetChallengeInvalid fails with a backend error instead of a fencing
+// A zombie can also lose its claim without being told: when its
+// SetChallengeInvalid fails with a backend error instead of a token
 // rejection, it goes on to recompute the authorization from reads taken
 // before the reclaiming retry settled. That stale write must not revert
-// the settled authorization any more than the fencing-rejection variant
+// the settled authorization any more than the token-rejection variant
 // (TestZombieInvalidationDoesNotRevertSettledAuthz) may.
 func TestZombieBackendErrorDoesNotRevertSettledAuthz(t *testing.T) {
 	t.Parallel()
@@ -411,7 +411,7 @@ func TestZombieBackendErrorDoesNotRevertSettledAuthz(t *testing.T) {
 	<-verifier.entered[1]
 
 	// The zombie fails verification while the retry holds the reservation,
-	// but its SetChallengeInvalid reports a backend error, not the fencing
+	// but its SetChallengeInvalid reports a backend error, not the token
 	// rejection. If it recomputes the authorization anyway, its stale
 	// write parks; if it treats the lost claim as settled, it finishes
 	// without writing.

--- a/handlers_storage_test.go
+++ b/handlers_storage_test.go
@@ -1249,7 +1249,7 @@ func TestSettledAuthorizationOmitsAttestation(t *testing.T) {
 }
 
 // completeOrderRacedStorage simulates a zombie finalize whose lease lapsed
-// mid-issuance: by the time its fenced completion lands, a retry has
+// mid-issuance: by the time its CompleteOrder write lands, a retry has
 // reclaimed the reservation, so the write reports ErrReserved.
 type completeOrderRacedStorage struct {
 	nanoca.Storage

--- a/storage.go
+++ b/storage.go
@@ -18,15 +18,15 @@ import (
 //     consumed nonce, and ErrNonceExpired after consuming an expired one.
 //   - CreateAccount must return ErrAccountExists, atomically with the
 //     write, if an account already exists with the same key thumbprint.
-//   - SetOrderStatus, SettleAuthorization, and the reserve/fenced methods
+//   - SetOrderStatus, SettleAuthorization, and the reservation methods
 //     below must return ErrStatusMismatch, atomically with the write, when
 //     the record is not in the expected preceding status.
 //   - Reserve* must return ErrReserved, atomically with the write, while
-//     an unexpired reservation is held; the fenced writes (CompleteOrder,
-//     ReleaseOrderFinalize, ReleaseChallengeValidation, SetChallengeValid,
-//     SetChallengeInvalid) must return ErrReserved when the presented token
-//     does not match the stored reservation. Successful fenced writes clear
-//     the reservation.
+//     an unexpired reservation is held; the writes that take a reservation
+//     token (CompleteOrder, ReleaseOrderFinalize, ReleaseChallengeValidation,
+//     SetChallengeValid, SetChallengeInvalid) must return ErrReserved when
+//     the presented token does not match the stored reservation, and clear
+//     the reservation on success.
 //
 // Reservation leases are judged by comparing the stored ReservedAt against
 // the caller-supplied duration with the backend's clock, so a shared
@@ -70,7 +70,7 @@ type Storage interface {
 	// ReleaseOrderFinalize surrenders a finalize reservation, transitioning
 	// the order from processing to `to` — ready, so a retry can finalize
 	// again, or invalid, for a terminal failure — and clearing the
-	// reservation. The write is fenced by token.
+	// reservation. The write requires the matching token.
 	ReleaseOrderFinalize(ctx context.Context, id, token, to string) error
 	GetOrdersByAccount(ctx context.Context, accountID string) ([]*Order, error)
 
@@ -92,22 +92,23 @@ type Storage interface {
 	ReserveChallengeValidation(ctx context.Context, id, reservationToken string, lease time.Duration) error
 	// ReleaseChallengeValidation surrenders a validation reservation,
 	// returning the challenge from processing to pending so a retry can
-	// validate again after a transient failure. The write is fenced by
-	// reservationToken.
+	// validate again after a transient failure. The write requires the
+	// matching reservationToken.
 	ReleaseChallengeValidation(ctx context.Context, id, reservationToken string) error
 	// SetChallengeValid stores the raw CBOR attestation object beside the
 	// status; it is opaque to storage and re-verified byte-for-byte at
-	// finalize. The write is fenced by reservationToken and clears the
-	// reservation.
+	// finalize. The write requires the matching reservationToken and clears
+	// the reservation.
 	SetChallengeValid(ctx context.Context, id, reservationToken string, validated time.Time, attestation []byte) error
 	SetChallengeInvalid(ctx context.Context, id, reservationToken string, validated time.Time, problem *Problem) error
 
 	// CompleteOrder atomically stores the certificate under Certificate.ID
 	// — the identifier GetCertificate looks up — and transitions the order
-	// from processing to valid, clearing its reservation; the write is
-	// fenced by token, so a finalize whose reservation was reclaimed cannot
-	// persist a certificate for a stale CSR. On error neither write is
-	// persisted, so a stored certificate always belongs to a valid order.
+	// from processing to valid, clearing its reservation; the write
+	// requires the matching token, so a finalize whose reservation was
+	// reclaimed cannot persist a certificate for a stale CSR. On error
+	// neither write is persisted, so a stored certificate always belongs
+	// to a valid order.
 	CompleteOrder(ctx context.Context, order *Order, cert *Certificate, token string) error
 	GetCertificate(ctx context.Context, id string) (*Certificate, error)
 

--- a/storage/badger/storage.go
+++ b/storage/badger/storage.go
@@ -133,7 +133,7 @@ func setJSON(txn *badger.Txn, key []byte, resource string, v any) error {
 }
 
 // reservedRecord points at the status and reservation fields the
-// reserve/fence state machine manipulates, so orders and challenges share
+// reservation state machine manipulates, so orders and challenges share
 // one implementation of its transitions.
 type reservedRecord struct {
 	status      *string
@@ -168,9 +168,9 @@ func (r reservedRecord) reserve(from, token string, lease time.Duration) error {
 	return nil
 }
 
-// fence admits a write only from the reservation's holder and clears the
+// consume admits a write only from the reservation's holder and clears the
 // reservation; the caller sets the resulting status.
-func (r reservedRecord) fence(token string) error {
+func (r reservedRecord) consume(token string) error {
 	if *r.status != r.processing {
 		return fmt.Errorf("%s status is %s, not %s: %w", r.resource, *r.status, r.processing, nanoca.ErrStatusMismatch)
 	}
@@ -349,7 +349,7 @@ func (s *Storage) ReleaseOrderFinalize(_ context.Context, id, token, to string) 
 		if err := getJSON(txn, orderKey(id), "order", &order); err != nil {
 			return err
 		}
-		if err := orderRecord(&order).fence(token); err != nil {
+		if err := orderRecord(&order).consume(token); err != nil {
 			return err
 		}
 		order.Status = to
@@ -473,7 +473,7 @@ func (s *Storage) settleChallenge(id, reservationToken string, updateFn func(*na
 		if err := getJSON(txn, challengeKey(id), "challenge", &challenge); err != nil {
 			return err
 		}
-		if err := challengeRecord(&challenge).fence(reservationToken); err != nil {
+		if err := challengeRecord(&challenge).consume(reservationToken); err != nil {
 			return err
 		}
 		updateFn(&challenge)
@@ -518,7 +518,7 @@ func (s *Storage) CompleteOrder(_ context.Context, order *nanoca.Order, cert *na
 		if err := getJSON(txn, orderKey(order.ID), "order", &stored); err != nil {
 			return err
 		}
-		if err := orderRecord(&stored).fence(token); err != nil {
+		if err := orderRecord(&stored).consume(token); err != nil {
 			return err
 		}
 

--- a/storage/badger/storage_test.go
+++ b/storage/badger/storage_test.go
@@ -456,7 +456,7 @@ func TestStorage_ChallengeOperations(t *testing.T) {
 		now := time.Now()
 		attestation := []byte("attestation-object")
 
-		// the write is fenced: a stale holder's token is rejected
+		// a stale holder's token is rejected
 		if err := storage.SetChallengeValid(ctx, challenge.ID, "stale", now, attestation); !errors.Is(err, nanoca.ErrReserved) {
 			t.Errorf("SetChallengeValid(stale token) error = %v, want ErrReserved", err)
 		}


### PR DESCRIPTION
The reservation tokens are checked for equality against the current holder, not ordered, so the fencing-token label from the distributed-systems literature implies semantics the design does not have. Reword comments to say what the writes actually require and rename the private helpers (fence to consume, isFenceRejection to lostRace). No behavior change.