### PR TITLE
docs: state storage contract edge cases and reservation lease sizing

### DIFF
--- a/ca.go
+++ b/ca.go
@@ -56,7 +56,10 @@ func WithPrefix(prefix string) Option {
 // WithReservationLease sets how long a finalize or challenge-validation
 // reservation is honored before another request may reclaim it. It bounds
 // how long a crashed instance can hold an order or challenge in processing,
-// and must exceed the worst-case verifier, authorizer, and issuer latency.
+// and must exceed the worst-case verifier, authorizer, and issuer latency,
+// plus any wall-clock skew between CA hosts sharing the store: a reader
+// whose clock runs ahead sees the lease shortened by the skew. The default
+// is one minute.
 func WithReservationLease(d time.Duration) Option {
 	return func(ca *CA) {
 		ca.reservationLease = d

--- a/storage.go
+++ b/storage.go
@@ -13,7 +13,9 @@ import (
 // internal server errors.
 //
 //   - Get*, Update*, Settle*, Reserve*, and SetChallenge* must return
-//     ErrNotFound when the object does not exist.
+//     ErrNotFound when the object does not exist. GetOrdersByAccount is the
+//     exception: an account with no orders yields an empty slice and no
+//     error.
 //   - ConsumeNonce must return ErrNotFound for an unknown or already
 //     consumed nonce, and ErrNonceExpired after consuming an expired one.
 //   - CreateAccount must return ErrAccountExists, atomically with the
@@ -26,7 +28,9 @@ import (
 //     token (CompleteOrder, ReleaseOrderFinalize, ReleaseChallengeValidation,
 //     SetChallengeValid, SetChallengeInvalid) must return ErrReserved when
 //     the presented token does not match the stored reservation, and clear
-//     the reservation on success.
+//     the reservation on success. The lease is judged only at reserve time:
+//     a write with the matching token must succeed even after the lease has
+//     lapsed, so a slow holder that was not superseded can still commit.
 //
 // Reservation leases are judged by comparing the stored ReservedAt against
 // the caller-supplied duration with the backend's clock, so a shared


### PR DESCRIPTION
Documents two contract details storage implementers would otherwise have to infer from the badger backend: GetOrdersByAccount returns an empty slice rather than ErrNotFound, and the lease is judged only at reserve time, so a write with the matching token succeeds even after the lease lapses. Also documents lease sizing in the WithReservationLease option doc.