### PR TITLE
refactor: simplify challenge settling and reservation presentation

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -408,11 +408,8 @@ func (ca *CA) handleOrder(w http.ResponseWriter, r *http.Request) {
 	// A crash mid-finalize leaves the order processing in storage, and an
 	// RFC 8555 Section 7.1.6 client polls processing without re-submitting
 	// finalize; once the reservation lapses the order must read as ready
-	// again so a retry can reclaim it. Presentation only — the durable
-	// reclaim happens when the retry reserves.
-	if order.Status == OrderStatusProcessing && !order.Reservation.Live(ca.reservationLease) {
-		order.Status = OrderStatusReady
-	}
+	// again so a retry can reclaim it.
+	order.presentLapsed(ca.reservationLease)
 
 	if postData.postAsGet {
 		ca.writeJSONResponseWithNonce(ctx, w, http.StatusOK, order)
@@ -520,11 +517,7 @@ func (ca *CA) handleChallenge(w http.ResponseWriter, r *http.Request) {
 	// and an RFC 8555 Section 7.1.6 client polls after responding once
 	// rather than re-POSTing; once the reservation lapses the challenge
 	// must read as pending again so the client can respond anew.
-	// Presentation only — the durable reclaim happens when the retry
-	// reserves.
-	if challenge.Status == ChallengeStatusProcessing && !challenge.Reservation.Live(ca.reservationLease) {
-		challenge.Status = ChallengeStatusPending
-	}
+	challenge.presentLapsed(ca.reservationLease)
 
 	if postData.postAsGet {
 		ca.writeJSONResponseWithNonce(ctx, w, http.StatusOK, challenge)
@@ -545,7 +538,7 @@ func (ca *CA) handleChallenge(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ca.handleChallengeResponse(ctx, w, challenge, postData)
+	ca.handleChallengeResponse(ctx, w, challenge, authz, postData)
 }
 
 func (ca *CA) handleCertificate(w http.ResponseWriter, r *http.Request) {
@@ -803,7 +796,7 @@ func (ca *CA) createOrder(ctx context.Context, accountID string, orderReq OrderR
 	return order, nil
 }
 
-func (ca *CA) handleChallengeResponse(ctx context.Context, w http.ResponseWriter, challenge *Challenge, postData *authenticatedPOST) {
+func (ca *CA) handleChallengeResponse(ctx context.Context, w http.ResponseWriter, challenge *Challenge, authz *Authorization, postData *authenticatedPOST) {
 	var challengeResp ChallengeRequest
 	if err := json.Unmarshal(postData.body, &challengeResp); err != nil {
 		ca.logger.ErrorContext(ctx, "Failed to parse challenge response", "error", err)
@@ -874,7 +867,7 @@ func (ca *CA) handleChallengeResponse(ctx context.Context, w http.ResponseWriter
 	deviceInfo, err := verifier.Verify(ctx, stmt, []byte(challenge.Token))
 	if err != nil {
 		ca.logger.ErrorContext(ctx, "Attestation verification failed", "challenge_id", challenge.ID, "error", err)
-		ca.failChallenge(ctx, w, challenge, reservationToken, Unauthorized("Attestation verification failed"))
+		ca.failChallenge(ctx, w, challenge, authz, reservationToken, Unauthorized("Attestation verification failed"))
 		return
 	}
 	// A validation that proves no identity must not settle valid: finalize
@@ -882,7 +875,7 @@ func (ca *CA) handleChallengeResponse(ctx context.Context, w http.ResponseWriter
 	// order that yields none, so accepting it here would wedge the order.
 	if deviceInfo == nil {
 		ca.logger.ErrorContext(ctx, "Attestation verifier returned no device identity", "challenge_id", challenge.ID, "format", attObj.Format)
-		ca.failChallenge(ctx, w, challenge, reservationToken, Unauthorized("Attestation yielded no device identity"))
+		ca.failChallenge(ctx, w, challenge, authz, reservationToken, Unauthorized("Attestation yielded no device identity"))
 		return
 	}
 
@@ -891,9 +884,10 @@ func (ca *CA) handleChallengeResponse(ctx context.Context, w http.ResponseWriter
 		ca.logger.ErrorContext(ctx, "Device authorization check failed", "challenge_id", challenge.ID, "error", err)
 
 		// A failed authorizer call is a backend condition, not a verdict on
-		// the attestation; surrender the reservation so a retry can
-		// validate once it clears, instead of invalidating the challenge.
-		if releaseErr := ca.storage.ReleaseChallengeValidation(ctx, challenge.ID, reservationToken); releaseErr != nil {
+		// the attestation; settle back to pending so a retry can validate
+		// once it clears, instead of invalidating the challenge.
+		challenge.settlePending()
+		if releaseErr := ca.storage.SettleChallenge(ctx, challenge, reservationToken); releaseErr != nil {
 			// A lost race means another request settled the
 			// challenge; its result stands. Anything else leaves the
 			// challenge processing, and it heals by lease expiry.
@@ -908,12 +902,12 @@ func (ca *CA) handleChallengeResponse(ctx context.Context, w http.ResponseWriter
 
 	if !authorized {
 		ca.logger.WarnContext(ctx, "Device not authorized", "challenge_id", challenge.ID)
-		ca.failChallenge(ctx, w, challenge, reservationToken, Unauthorized("Device not authorized for certificate issuance"))
+		ca.failChallenge(ctx, w, challenge, authz, reservationToken, Unauthorized("Device not authorized for certificate issuance"))
 		return
 	}
 
-	now := time.Now()
-	if err := ca.storage.SetChallengeValid(ctx, challenge.ID, reservationToken, now, attObjBytes); err != nil {
+	challenge.settleValid(time.Now(), attObjBytes)
+	if err := ca.storage.SettleChallenge(ctx, challenge, reservationToken); err != nil {
 		// Another writer settled the challenge first; report its result.
 		if lostRace(err) {
 			ca.reportChallengeState(ctx, w, challenge.ID)
@@ -926,19 +920,8 @@ func (ca *CA) handleChallengeResponse(ctx context.Context, w http.ResponseWriter
 
 	ca.logger.InfoContext(ctx, "Challenge validated", "challenge_id", challenge.ID, "type", challenge.Type)
 
-	if authz, err := ca.storage.GetAuthorization(ctx, challenge.AuthzID); err == nil {
-		ca.updateAuthorizationStatus(ctx, authz)
-	} else {
-		// The challenge is already valid, so nothing re-runs this refresh;
-		// the authorization stays pending until the client polls it.
-		ca.logger.ErrorContext(ctx, "Failed to get authorization after challenge validation", "error", err)
-	}
+	ca.updateAuthorizationStatus(ctx, authz)
 
-	challenge, err = ca.storage.GetChallenge(ctx, challenge.ID)
-	if err != nil {
-		ca.writeProblem(ctx, w, InternalServerError("Failed to retrieve challenge after validation").WithCause(err))
-		return
-	}
 	ca.writeJSONResponseWithNonce(ctx, w, http.StatusOK, challenge)
 }
 
@@ -956,8 +939,9 @@ func (ca *CA) reportChallengeState(ctx context.Context, w http.ResponseWriter, c
 // failChallenge settles a reserved challenge as invalid and reports prob. A
 // lost race means another request settled the challenge first: its
 // result is reported instead and the recompute is left to it.
-func (ca *CA) failChallenge(ctx context.Context, w http.ResponseWriter, challenge *Challenge, reservationToken string, prob *Problem) {
-	if err := ca.storage.SetChallengeInvalid(ctx, challenge.ID, reservationToken, time.Now(), prob); err != nil {
+func (ca *CA) failChallenge(ctx context.Context, w http.ResponseWriter, challenge *Challenge, authz *Authorization, reservationToken string, prob *Problem) {
+	challenge.settleInvalid(time.Now(), prob)
+	if err := ca.storage.SettleChallenge(ctx, challenge, reservationToken); err != nil {
 		if lostRace(err) {
 			ca.reportChallengeState(ctx, w, challenge.ID)
 			return
@@ -965,11 +949,7 @@ func (ca *CA) failChallenge(ctx context.Context, w http.ResponseWriter, challeng
 		ca.logger.ErrorContext(ctx, "Failed to update challenge status", "error", err)
 	}
 
-	if authz, err := ca.storage.GetAuthorization(ctx, challenge.AuthzID); err == nil {
-		ca.updateAuthorizationStatus(ctx, authz)
-	} else {
-		ca.logger.ErrorContext(ctx, "Failed to get authorization after challenge failure", "error", err)
-	}
+	ca.updateAuthorizationStatus(ctx, authz)
 	ca.writeProblem(ctx, w, prob)
 }
 
@@ -1052,9 +1032,7 @@ func (ca *CA) updateAuthorizationStatus(ctx context.Context, authz *Authorizatio
 		// here for the same reason handleChallenge presents it that way: an
 		// RFC 8555 Section 7.5.1 client polls the authorization object, and
 		// a challenge shown as processing forever would never be re-POSTed.
-		if currentChallenge.Status == ChallengeStatusProcessing && !currentChallenge.Reservation.Live(ca.reservationLease) {
-			currentChallenge.Status = ChallengeStatusPending
-		}
+		currentChallenge.presentLapsed(ca.reservationLease)
 
 		// Reservations and attestation blobs belong to the challenge
 		// record, not embedded copies.

--- a/handlers_recovery_test.go
+++ b/handlers_recovery_test.go
@@ -89,7 +89,7 @@ func (s *authzWriteParkingStorage) SettleAuthorization(ctx context.Context, auth
 	return s.Storage.SettleAuthorization(ctx, authz)
 }
 
-// A zombie validation whose SetChallengeInvalid write is rejected has no
+// A zombie validation whose invalid settlement is rejected has no
 // claim left on the challenge, yet it still recomputes the authorization.
 // Its stale write must not revert an authorization a reclaiming retry has
 // settled valid: with the order already ready, a reverted authorization is
@@ -133,7 +133,7 @@ func TestZombieInvalidationDoesNotRevertSettledAuthz(t *testing.T) {
 	<-verifier.entered[1]
 
 	// The zombie fails verification while the retry holds the reservation,
-	// so its SetChallengeInvalid write is rejected. If it goes on to
+	// so its invalid settlement is rejected. If it goes on to
 	// recompute the authorization anyway, its stale write parks; if it
 	// stops at the rejected write, it finishes without writing.
 	storage.park(1)
@@ -341,7 +341,7 @@ func TestOrderReadyRetriesAfterStatusWriteFailure(t *testing.T) {
 	}
 }
 
-// challengeInvalidFailingStorage fails SetChallengeInvalid with a plain
+// challengeInvalidFailingStorage fails the invalid settlement with a plain
 // backend error while armed, so failChallenge takes its backend-error branch
 // and never learns another request has claimed the challenge.
 type challengeInvalidFailingStorage struct {
@@ -356,19 +356,19 @@ func (s *challengeInvalidFailingStorage) arm() {
 	s.mu.Unlock()
 }
 
-func (s *challengeInvalidFailingStorage) SetChallengeInvalid(ctx context.Context, id, reservationToken string, validated time.Time, problem *nanoca.Problem) error {
+func (s *challengeInvalidFailingStorage) SettleChallenge(ctx context.Context, challenge *nanoca.Challenge, reservationToken string) error {
 	s.mu.Lock()
 	armed := s.armed
 	s.mu.Unlock()
-	if armed {
+	if armed && challenge.Status == nanoca.ChallengeStatusInvalid {
 		return errors.New("backend unavailable")
 	}
-	return s.Storage.SetChallengeInvalid(ctx, id, reservationToken, validated, problem)
+	return s.Storage.SettleChallenge(ctx, challenge, reservationToken)
 }
 
-// A zombie can also lose its claim without being told: when its
-// SetChallengeInvalid fails with a backend error instead of a token
-// rejection, it goes on to recompute the authorization from reads taken
+// A zombie can also lose its claim without being told: when its invalid
+// settlement fails with a backend error instead of a token rejection, it
+// goes on to recompute the authorization from reads taken
 // before the reclaiming retry settled. That stale write must not revert
 // the settled authorization any more than the token-rejection variant
 // (TestZombieInvalidationDoesNotRevertSettledAuthz) may.
@@ -411,7 +411,7 @@ func TestZombieBackendErrorDoesNotRevertSettledAuthz(t *testing.T) {
 	<-verifier.entered[1]
 
 	// The zombie fails verification while the retry holds the reservation,
-	// but its SetChallengeInvalid reports a backend error, not the token
+	// but its settle write reports a backend error, not the token
 	// rejection. If it recomputes the authorization anyway, its stale
 	// write parks; if it treats the lost claim as settled, it finishes
 	// without writing.

--- a/handlers_storage_test.go
+++ b/handlers_storage_test.go
@@ -604,8 +604,13 @@ type corruptAttestationStorage struct {
 	nanoca.Storage
 }
 
-func (s corruptAttestationStorage) SetChallengeValid(ctx context.Context, id, reservationToken string, validated time.Time, attestation []byte) error {
-	return s.Storage.SetChallengeValid(ctx, id, reservationToken, validated, attestation[:1])
+func (s corruptAttestationStorage) SettleChallenge(ctx context.Context, challenge *nanoca.Challenge, reservationToken string) error {
+	if len(challenge.Attestation) > 0 {
+		truncated := *challenge
+		truncated.Attestation = challenge.Attestation[:1]
+		return s.Storage.SettleChallenge(ctx, &truncated, reservationToken)
+	}
+	return s.Storage.SettleChallenge(ctx, challenge, reservationToken)
 }
 
 // An order whose stored attestation can never be re-verified is stuck: a
@@ -890,7 +895,7 @@ func TestFinalizeRecoversAfterRollbackFailure(t *testing.T) {
 	}
 }
 
-// challengeValidFailingOnceStorage fails the first SetChallengeValid,
+// challengeValidFailingOnceStorage fails the first valid settlement,
 // stranding a verified challenge in "processing" under a live reservation
 // the way a crash between the reserve and the terminal write would.
 type challengeValidFailingOnceStorage struct {
@@ -899,15 +904,17 @@ type challengeValidFailingOnceStorage struct {
 	failed bool
 }
 
-func (s *challengeValidFailingOnceStorage) SetChallengeValid(ctx context.Context, id, reservationToken string, validated time.Time, attestation []byte) error {
-	s.mu.Lock()
-	first := !s.failed
-	s.failed = true
-	s.mu.Unlock()
-	if first {
-		return errors.New("backend unavailable")
+func (s *challengeValidFailingOnceStorage) SettleChallenge(ctx context.Context, challenge *nanoca.Challenge, reservationToken string) error {
+	if challenge.Status == nanoca.ChallengeStatusValid {
+		s.mu.Lock()
+		first := !s.failed
+		s.failed = true
+		s.mu.Unlock()
+		if first {
+			return errors.New("backend unavailable")
+		}
 	}
-	return s.Storage.SetChallengeValid(ctx, id, reservationToken, validated, attestation)
+	return s.Storage.SettleChallenge(ctx, challenge, reservationToken)
 }
 
 // A challenge left in "processing" by an interrupted validation has no owner:
@@ -999,17 +1006,20 @@ type challengeValidRacedStorage struct {
 	nanoca.Storage
 }
 
-func (s challengeValidRacedStorage) SetChallengeValid(ctx context.Context, id, reservationToken string, validated time.Time, attestation []byte) error {
-	if err := s.Storage.SetChallengeValid(ctx, id, reservationToken, validated, attestation); err != nil {
+func (s challengeValidRacedStorage) SettleChallenge(ctx context.Context, challenge *nanoca.Challenge, reservationToken string) error {
+	if err := s.Storage.SettleChallenge(ctx, challenge, reservationToken); err != nil {
 		return err
+	}
+	if challenge.Status != nanoca.ChallengeStatusValid {
+		return nil
 	}
 	return fmt.Errorf("challenge status is valid, not processing: %w", nanoca.ErrStatusMismatch)
 }
 
 // Losing the terminal write to a concurrent validation is the same
-// client-state condition the SetChallengeProcessing path reports with the
-// challenge's current state; a 500 invites the client to retry a challenge
-// that has already succeeded.
+// client-state condition the reserve path reports with the challenge's
+// current state; a 500 invites the client to retry a challenge that has
+// already succeeded.
 func TestChallengeValidStatusMismatchReportsState(t *testing.T) {
 	t.Parallel()
 

--- a/storage.go
+++ b/storage.go
@@ -12,10 +12,9 @@ import (
 // backend failure. Operations that fail for any other reason are treated as
 // internal server errors.
 //
-//   - Get*, Update*, Settle*, Reserve*, and SetChallenge* must return
-//     ErrNotFound when the object does not exist. GetOrdersByAccount is the
-//     exception: an account with no orders yields an empty slice and no
-//     error.
+//   - Get*, Update*, Settle*, and Reserve* must return ErrNotFound when
+//     the object does not exist. GetOrdersByAccount is the exception: an
+//     account with no orders yields an empty slice and no error.
 //   - ConsumeNonce must return ErrNotFound for an unknown or already
 //     consumed nonce, and ErrNonceExpired after consuming an expired one.
 //   - CreateAccount must return ErrAccountExists, atomically with the
@@ -25,10 +24,10 @@ import (
 //     the record is not in the expected preceding status.
 //   - Reserve* must return ErrReserved, atomically with the write, while
 //     an unexpired reservation is held; the writes that take a reservation
-//     token (CompleteOrder, ReleaseOrderFinalize, ReleaseChallengeValidation,
-//     SetChallengeValid, SetChallengeInvalid) must return ErrReserved when
-//     the presented token does not match the stored reservation, and clear
-//     the reservation on success. The lease is judged only at reserve time:
+//     token (CompleteOrder, ReleaseOrderFinalize, SettleChallenge) must
+//     return ErrReserved when the presented token does not match the stored
+//     reservation, and clear the reservation on success. The lease is
+//     judged only at reserve time:
 //     a write with the matching token must succeed even after the lease has
 //     lapsed, so a slow holder that was not superseded can still commit.
 //
@@ -94,17 +93,15 @@ type Storage interface {
 	// challenge, with the same contract as ReserveOrderFinalize: pending to
 	// processing, or reclaim of an expired reservation.
 	ReserveChallengeValidation(ctx context.Context, id, reservationToken string, lease time.Duration) error
-	// ReleaseChallengeValidation surrenders a validation reservation,
-	// returning the challenge from processing to pending so a retry can
-	// validate again after a transient failure. The write requires the
-	// matching reservationToken.
-	ReleaseChallengeValidation(ctx context.Context, id, reservationToken string) error
-	// SetChallengeValid stores the raw CBOR attestation object beside the
-	// status; it is opaque to storage and re-verified byte-for-byte at
-	// finalize. The write requires the matching reservationToken and clears
-	// the reservation.
-	SetChallengeValid(ctx context.Context, id, reservationToken string, validated time.Time, attestation []byte) error
-	SetChallengeInvalid(ctx context.Context, id, reservationToken string, validated time.Time, problem *Problem) error
+	// SettleChallenge settles a reserved challenge, transitioning it from
+	// processing to challenge.Status and clearing the reservation; the
+	// write requires the matching reservationToken. The full record is
+	// written, so the settlement's fields (Validated, Error, and the raw
+	// attestation object, which is opaque to storage and re-verified
+	// byte-for-byte at finalize) land with the transition. Settling back
+	// to pending surrenders the reservation so a retry can validate again
+	// after a transient failure.
+	SettleChallenge(ctx context.Context, challenge *Challenge, reservationToken string) error
 
 	// CompleteOrder atomically stores the certificate under Certificate.ID
 	// — the identifier GetCertificate looks up — and transitions the order

--- a/storage/badger/errors_test.go
+++ b/storage/badger/errors_test.go
@@ -47,8 +47,8 @@ func TestNotFoundErrors(t *testing.T) {
 		{"ReserveChallengeValidation", func() error {
 			return s.ReserveChallengeValidation(ctx, "ghost", "token", time.Minute)
 		}},
-		{"ReleaseChallengeValidation", func() error {
-			return s.ReleaseChallengeValidation(ctx, "ghost", "token")
+		{"SettleChallenge", func() error {
+			return s.SettleChallenge(ctx, &nanoca.Challenge{ID: "ghost"}, "token")
 		}},
 		{"ReserveOrderFinalize", func() error {
 			return s.ReserveOrderFinalize(ctx, "ghost", "token", time.Minute)

--- a/storage/badger/storage.go
+++ b/storage/badger/storage.go
@@ -467,41 +467,19 @@ func (s *Storage) ReserveChallengeValidation(_ context.Context, id, reservationT
 	})
 }
 
-func (s *Storage) settleChallenge(id, reservationToken string, updateFn func(*nanoca.Challenge)) error {
+func (s *Storage) SettleChallenge(_ context.Context, challenge *nanoca.Challenge, reservationToken string) error {
+	settled := *challenge
+	settled.Reservation = nil
+
 	return s.update(func(txn *badger.Txn) error {
-		var challenge nanoca.Challenge
-		if err := getJSON(txn, challengeKey(id), "challenge", &challenge); err != nil {
+		var stored nanoca.Challenge
+		if err := getJSON(txn, challengeKey(challenge.ID), "challenge", &stored); err != nil {
 			return err
 		}
-		if err := challengeRecord(&challenge).consume(reservationToken); err != nil {
+		if err := challengeRecord(&stored).consume(reservationToken); err != nil {
 			return err
 		}
-		updateFn(&challenge)
-
-		return setJSON(txn, challengeKey(id), "challenge", &challenge)
-	})
-}
-
-func (s *Storage) SetChallengeValid(_ context.Context, id, reservationToken string, validated time.Time, attestation []byte) error {
-	return s.settleChallenge(id, reservationToken, func(c *nanoca.Challenge) {
-		c.Status = nanoca.ChallengeStatusValid
-		c.Validated = &validated
-		c.Attestation = attestation
-		c.Error = nil
-	})
-}
-
-func (s *Storage) SetChallengeInvalid(_ context.Context, id, reservationToken string, validated time.Time, problem *nanoca.Problem) error {
-	return s.settleChallenge(id, reservationToken, func(c *nanoca.Challenge) {
-		c.Status = nanoca.ChallengeStatusInvalid
-		c.Validated = &validated
-		c.Error = problem
-	})
-}
-
-func (s *Storage) ReleaseChallengeValidation(_ context.Context, id, reservationToken string) error {
-	return s.settleChallenge(id, reservationToken, func(c *nanoca.Challenge) {
-		c.Status = nanoca.ChallengeStatusPending
+		return setJSON(txn, challengeKey(challenge.ID), "challenge", &settled)
 	})
 }
 

--- a/storage/badger/storage_test.go
+++ b/storage/badger/storage_test.go
@@ -434,7 +434,7 @@ func TestStorage_ChallengeOperations(t *testing.T) {
 		}
 	})
 
-	t.Run("SetChallengeValid", func(t *testing.T) {
+	t.Run("SettleChallenge valid", func(t *testing.T) {
 		t.Parallel()
 
 		storage := newTestStorage(t)
@@ -454,15 +454,18 @@ func TestStorage_ChallengeOperations(t *testing.T) {
 		}
 
 		now := time.Now()
-		attestation := []byte("attestation-object")
+		settled := *challenge
+		settled.Status = nanoca.ChallengeStatusValid
+		settled.Validated = &now
+		settled.Attestation = []byte("attestation-object")
 
 		// a stale holder's token is rejected
-		if err := storage.SetChallengeValid(ctx, challenge.ID, "stale", now, attestation); !errors.Is(err, nanoca.ErrReserved) {
-			t.Errorf("SetChallengeValid(stale token) error = %v, want ErrReserved", err)
+		if err := storage.SettleChallenge(ctx, &settled, "stale"); !errors.Is(err, nanoca.ErrReserved) {
+			t.Errorf("SettleChallenge(stale token) error = %v, want ErrReserved", err)
 		}
 
-		if err := storage.SetChallengeValid(ctx, challenge.ID, "t1", now, attestation); err != nil {
-			t.Fatalf("SetChallengeValid() error = %v", err)
+		if err := storage.SettleChallenge(ctx, &settled, "t1"); err != nil {
+			t.Fatalf("SettleChallenge() error = %v", err)
 		}
 
 		retrieved, err := storage.GetChallenge(ctx, challenge.ID)
@@ -485,18 +488,18 @@ func TestStorage_ChallengeOperations(t *testing.T) {
 			t.Error("Reservation should be cleared by the terminal write")
 		}
 
-		// calling on a valid challenge should fail (expects processing)
-		if err := storage.SetChallengeValid(ctx, challenge.ID, "t1", now, nil); err == nil {
-			t.Error("SetChallengeValid() should fail when status is not processing")
+		// settling a valid challenge should fail (expects processing)
+		if err := storage.SettleChallenge(ctx, &settled, "t1"); err == nil {
+			t.Error("SettleChallenge() should fail when status is not processing")
 		}
 
 		// nonexistent challenge
-		if err := storage.SetChallengeValid(ctx, "nonexistent", "t1", now, nil); err == nil {
-			t.Error("SetChallengeValid() should fail for nonexistent challenge")
+		if err := storage.SettleChallenge(ctx, &nanoca.Challenge{ID: "nonexistent"}, "t1"); err == nil {
+			t.Error("SettleChallenge() should fail for nonexistent challenge")
 		}
 	})
 
-	t.Run("SetChallengeInvalid", func(t *testing.T) {
+	t.Run("SettleChallenge invalid", func(t *testing.T) {
 		t.Parallel()
 
 		storage := newTestStorage(t)
@@ -516,14 +519,17 @@ func TestStorage_ChallengeOperations(t *testing.T) {
 		}
 
 		now := time.Now()
-		prob := nanoca.Unauthorized("device not authorized")
+		settled := *challenge
+		settled.Status = nanoca.ChallengeStatusInvalid
+		settled.Validated = &now
+		settled.Error = nanoca.Unauthorized("device not authorized")
 
-		if err := storage.SetChallengeInvalid(ctx, challenge.ID, "stale", now, prob); !errors.Is(err, nanoca.ErrReserved) {
-			t.Errorf("SetChallengeInvalid(stale token) error = %v, want ErrReserved", err)
+		if err := storage.SettleChallenge(ctx, &settled, "stale"); !errors.Is(err, nanoca.ErrReserved) {
+			t.Errorf("SettleChallenge(stale token) error = %v, want ErrReserved", err)
 		}
 
-		if err := storage.SetChallengeInvalid(ctx, challenge.ID, "t1", now, prob); err != nil {
-			t.Fatalf("SetChallengeInvalid() error = %v", err)
+		if err := storage.SettleChallenge(ctx, &settled, "t1"); err != nil {
+			t.Fatalf("SettleChallenge() error = %v", err)
 		}
 
 		retrieved, err := storage.GetChallenge(ctx, challenge.ID)
@@ -543,14 +549,9 @@ func TestStorage_ChallengeOperations(t *testing.T) {
 			t.Error("Reservation should be cleared by the terminal write")
 		}
 
-		// calling on an invalid challenge should fail (expects processing)
-		if err := storage.SetChallengeInvalid(ctx, challenge.ID, "t1", now, prob); err == nil {
-			t.Error("SetChallengeInvalid() should fail when status is not processing")
-		}
-
-		// nonexistent challenge
-		if err := storage.SetChallengeInvalid(ctx, "nonexistent", "t1", now, prob); err == nil {
-			t.Error("SetChallengeInvalid() should fail for nonexistent challenge")
+		// settling an invalid challenge should fail (expects processing)
+		if err := storage.SettleChallenge(ctx, &settled, "t1"); err == nil {
+			t.Error("SettleChallenge() should fail when status is not processing")
 		}
 	})
 }
@@ -738,27 +739,28 @@ func TestReleaseOrderFinalize(t *testing.T) {
 	}
 }
 
-func TestReleaseChallengeValidation(t *testing.T) {
+func TestSettleChallengeToPending(t *testing.T) {
 	t.Parallel()
 
 	storage := newTestStorage(t)
 	ctx := t.Context()
 
-	if err := storage.CreateChallenge(ctx, &nanoca.Challenge{ID: "c1", Status: nanoca.ChallengeStatusPending}); err != nil {
+	pending := &nanoca.Challenge{ID: "c1", Status: nanoca.ChallengeStatusPending}
+	if err := storage.CreateChallenge(ctx, pending); err != nil {
 		t.Fatalf("CreateChallenge() error = %v", err)
 	}
-	if err := storage.ReleaseChallengeValidation(ctx, "c1", "t1"); !errors.Is(err, nanoca.ErrStatusMismatch) {
-		t.Errorf("ReleaseChallengeValidation(pending) error = %v, want ErrStatusMismatch", err)
+	if err := storage.SettleChallenge(ctx, pending, "t1"); !errors.Is(err, nanoca.ErrStatusMismatch) {
+		t.Errorf("SettleChallenge(pending) error = %v, want ErrStatusMismatch", err)
 	}
 
 	if err := storage.ReserveChallengeValidation(ctx, "c1", "t1", time.Minute); err != nil {
 		t.Fatalf("ReserveChallengeValidation() error = %v", err)
 	}
-	if err := storage.ReleaseChallengeValidation(ctx, "c1", "stale"); !errors.Is(err, nanoca.ErrReserved) {
-		t.Errorf("ReleaseChallengeValidation(stale token) error = %v, want ErrReserved", err)
+	if err := storage.SettleChallenge(ctx, pending, "stale"); !errors.Is(err, nanoca.ErrReserved) {
+		t.Errorf("SettleChallenge(stale token) error = %v, want ErrReserved", err)
 	}
-	if err := storage.ReleaseChallengeValidation(ctx, "c1", "t1"); err != nil {
-		t.Fatalf("ReleaseChallengeValidation() error = %v", err)
+	if err := storage.SettleChallenge(ctx, pending, "t1"); err != nil {
+		t.Fatalf("SettleChallenge() error = %v", err)
 	}
 
 	challenge, err := storage.GetChallenge(ctx, "c1")
@@ -769,7 +771,7 @@ func TestReleaseChallengeValidation(t *testing.T) {
 		t.Errorf("challenge status = %q, want %q", challenge.Status, nanoca.ChallengeStatusPending)
 	}
 	if challenge.Reservation != nil {
-		t.Error("Reservation should be cleared by release")
+		t.Error("Reservation should be cleared by settling back to pending")
 	}
 }
 

--- a/types.go
+++ b/types.go
@@ -178,6 +178,15 @@ const (
 	OrderStatusInvalid    = "invalid"
 )
 
+// presentLapsed rewrites a processing order whose reservation has lapsed
+// back to ready, the status a retry would reclaim it from. Presentation
+// only: the durable reclaim happens when the retry reserves.
+func (o *Order) presentLapsed(lease time.Duration) {
+	if o.Status == OrderStatusProcessing && !o.Reservation.Live(lease) {
+		o.Status = OrderStatusReady
+	}
+}
+
 const (
 	IdentifierTypePermanentIdentifier = "permanent-identifier"
 	IdentifierTypeHardwareModule      = "hardware-module"
@@ -233,6 +242,40 @@ const (
 	ChallengeStatusValid      = "valid"
 	ChallengeStatusInvalid    = "invalid"
 )
+
+// presentLapsed rewrites a processing challenge whose reservation has
+// lapsed back to pending, the status a retry would reclaim it from.
+// Presentation only: the durable reclaim happens when the retry reserves.
+func (c *Challenge) presentLapsed(lease time.Duration) {
+	if c.Status == ChallengeStatusProcessing && !c.Reservation.Live(lease) {
+		c.Status = ChallengeStatusPending
+	}
+}
+
+// The settle* helpers shape the record for SettleChallenge, which writes
+// it wholesale: each transition sets every settlement field so a call
+// site cannot persist a leftover from a prior state.
+
+func (c *Challenge) settleValid(validated time.Time, attestation []byte) {
+	c.Status = ChallengeStatusValid
+	c.Validated = &validated
+	c.Attestation = attestation
+	c.Error = nil
+}
+
+func (c *Challenge) settleInvalid(validated time.Time, problem *Problem) {
+	c.Status = ChallengeStatusInvalid
+	c.Validated = &validated
+	c.Attestation = nil
+	c.Error = problem
+}
+
+func (c *Challenge) settlePending() {
+	c.Status = ChallengeStatusPending
+	c.Validated = nil
+	c.Attestation = nil
+	c.Error = nil
+}
 
 const (
 	ChallengeTypeDeviceAttest01 = "device-attest-01"


### PR DESCRIPTION
Three related cleanups, no behavior change:

Shares the lapsed-reservation presentation rule (processing plus a lapsed lease reads as the prior status) in one helper instead of repeating it in handleOrder, handleChallenge, and updateAuthorizationStatus.

Passes the authorization handleChallenge already loaded and authenticated down to the settle paths, removing two GetAuthorization re-reads and their failure logging. A stale copy stays safe because SettleAuthorization rejects a recompute against a record another request has settled.

Collapses ReleaseChallengeValidation, SetChallengeValid, and SetChallengeInvalid into a single SettleChallenge that writes the caller's record the way SettleAuthorization does; the valid path then responds with the record it just wrote instead of re-reading it.